### PR TITLE
[SNK-68] 도메인 패키지 구성 및 주요 엔티티 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+application-jwt.yml
+

--- a/snackpot-api/build.gradle
+++ b/snackpot-api/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     // jwt
     implementation 'com.auth0:java-jwt:4.2.1'
     // Spring Data Redis
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+ㅇ    // implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // firebase
     implementation 'com.google.firebase:firebase-admin:9.1.1'
     // validation

--- a/snackpot-api/build.gradle
+++ b/snackpot-api/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     // jwt
     implementation 'com.auth0:java-jwt:4.2.1'
     // Spring Data Redis
-ㅇ    // implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // firebase
     implementation 'com.google.firebase:firebase-admin:9.1.1'
     // validation

--- a/snackpot-api/src/main/java/com/soma/SnackpotApiApplication.java
+++ b/snackpot-api/src/main/java/com/soma/SnackpotApiApplication.java
@@ -2,8 +2,10 @@ package com.soma;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class SnackpotApiApplication {
 
     public static void main(String[] args) {

--- a/snackpot-api/src/main/java/com/soma/advice/ErrorCode.java
+++ b/snackpot-api/src/main/java/com/soma/advice/ErrorCode.java
@@ -1,0 +1,14 @@
+package com.soma.advice;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    /* Member */
+    MEMBER_NOT_FOUND_EXCEPTION(-1100, "사용자가 존재하지 않습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/snackpot-api/src/main/java/com/soma/advice/ExceptionAdvice.java
+++ b/snackpot-api/src/main/java/com/soma/advice/ExceptionAdvice.java
@@ -1,0 +1,10 @@
+package com.soma.advice;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ExceptionAdvice {
+
+}

--- a/snackpot-api/src/main/java/com/soma/auth/controller/AuthController.java
+++ b/snackpot-api/src/main/java/com/soma/auth/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.soma.auth.controller;
+
+import com.soma.auth.dto.request.SignInRequest;
+import com.soma.auth.dto.request.SignUpRequest;
+import com.soma.auth.service.AuthService;
+import com.soma.util.response.Response;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+    @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.OK)
+    public Response signup(@RequestBody @Valid SignUpRequest request) {
+        return Response.success(authService.signup(request));
+    }
+
+    @PostMapping("/signin")
+    @ResponseStatus(HttpStatus.OK)
+    public Response login(@RequestBody @Valid SignInRequest request) {
+        return Response.success(authService.login(request));
+    }
+}

--- a/snackpot-api/src/main/java/com/soma/auth/dto/request/SignInRequest.java
+++ b/snackpot-api/src/main/java/com/soma/auth/dto/request/SignInRequest.java
@@ -1,0 +1,16 @@
+package com.soma.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class SignInRequest {
+    private String name;
+
+    @NotBlank(message = "fcm 토큰은 필수 값입니다.")
+    private String fcmToken;
+}

--- a/snackpot-api/src/main/java/com/soma/auth/dto/request/SignUpRequest.java
+++ b/snackpot-api/src/main/java/com/soma/auth/dto/request/SignUpRequest.java
@@ -1,0 +1,18 @@
+package com.soma.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignUpRequest {
+    private String name;
+
+    private Integer dailyGoalTime;
+
+    @NotBlank(message = "fcm 토큰은 필수 값입니다.")
+    private String fcmToken;
+}

--- a/snackpot-api/src/main/java/com/soma/auth/dto/response/SignInResponse.java
+++ b/snackpot-api/src/main/java/com/soma/auth/dto/response/SignInResponse.java
@@ -1,0 +1,13 @@
+package com.soma.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class SignInResponse {
+    private String accessToken;
+    private Long id;
+}

--- a/snackpot-api/src/main/java/com/soma/auth/dto/response/SignUpResponse.java
+++ b/snackpot-api/src/main/java/com/soma/auth/dto/response/SignUpResponse.java
@@ -1,0 +1,13 @@
+package com.soma.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignUpResponse {
+    private String accessToken;
+    private Long memberId;
+}

--- a/snackpot-api/src/main/java/com/soma/auth/service/AuthService.java
+++ b/snackpot-api/src/main/java/com/soma/auth/service/AuthService.java
@@ -1,0 +1,66 @@
+package com.soma.auth.service;
+
+
+import com.soma.auth.dto.request.SignInRequest;
+import com.soma.auth.dto.request.SignUpRequest;
+import com.soma.auth.dto.response.SignInResponse;
+import com.soma.auth.dto.response.SignUpResponse;
+import com.soma.common.constant.Status;
+import com.soma.exception.MemberNicknameAlreadyExistsException;
+import com.soma.exception.MemberNotFoundException;
+import com.soma.member.entity.Member;
+import com.soma.member.repository.MemberRepository;
+import com.soma.notification.service.NotificationService;
+import com.soma.security.jwt.service.JwtService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final MemberRepository memberRepository;
+    private final JwtService jwtService;
+    private final NotificationService notificationService;
+
+    @Transactional
+    public SignUpResponse signup(SignUpRequest request) {
+        String email = UUID.randomUUID() + "@socialUser.com";
+
+        validateDuplicateNickname(request);
+
+        Member member = Member.builder()
+                .email(email)
+                .name(request.getName())
+                .dailyGoalTime(request.getDailyGoalTime())
+                .build();
+        // fcm 토큰 저장
+        member.updateFcmToken(request.getFcmToken());
+
+        memberRepository.save(member);
+
+        String accessToken = jwtService.createAccessToken(email);
+
+        return new SignUpResponse("Bearer " + accessToken, member.getId());
+    }
+
+    @Transactional
+    public SignInResponse login(SignInRequest request) {
+        Member member = memberRepository.findByNameAndStatus(request.getName(), Status.ACTIVE).orElseThrow(MemberNotFoundException::new);
+
+        String accessToken = jwtService.createAccessToken(member.getEmail());
+
+        // fcm 토큰 저장
+        member.updateFcmToken(request.getFcmToken());
+
+        return new SignInResponse("Bearer " + accessToken, member.getId());
+    }
+
+    private void validateDuplicateNickname(SignUpRequest request) {
+        if (memberRepository.existsByName(request.getName())) {
+            throw new MemberNicknameAlreadyExistsException();
+        }
+    }
+}

--- a/snackpot-api/src/main/java/com/soma/exception/MemberNicknameAlreadyExistsException.java
+++ b/snackpot-api/src/main/java/com/soma/exception/MemberNicknameAlreadyExistsException.java
@@ -1,0 +1,4 @@
+package com.soma.exception;
+
+public class MemberNicknameAlreadyExistsException extends RuntimeException{
+}

--- a/snackpot-api/src/main/java/com/soma/exception/MemberNotFoundException.java
+++ b/snackpot-api/src/main/java/com/soma/exception/MemberNotFoundException.java
@@ -1,0 +1,4 @@
+package com.soma.exception;
+
+public class MemberNotFoundException extends RuntimeException{
+}

--- a/snackpot-api/src/main/java/com/soma/group/entity/Group.java
+++ b/snackpot-api/src/main/java/com/soma/group/entity/Group.java
@@ -1,0 +1,27 @@
+package com.soma.group.entity;
+
+import com.soma.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "Exgroup")
+@Entity
+public class Group extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private LocalDate startDate; // 시작 기간
+
+    private String code; // 그룹 입장 코드
+}

--- a/snackpot-api/src/main/java/com/soma/group/repository/GroupRepository.java
+++ b/snackpot-api/src/main/java/com/soma/group/repository/GroupRepository.java
@@ -1,0 +1,7 @@
+package com.soma.group.repository;
+
+import com.soma.group.entity.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+}

--- a/snackpot-api/src/main/java/com/soma/member/entity/Member.java
+++ b/snackpot-api/src/main/java/com/soma/member/entity/Member.java
@@ -1,0 +1,45 @@
+package com.soma.member.entity;
+
+import com.soma.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Member extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String email;
+
+    private Integer dailyGoalTime;
+
+    private String profileImg;
+
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private RoleType roleType;
+
+    private String fcmToken;
+
+    @Builder
+    public Member(String email, String name, Integer dailyGoalTime) {
+        this.email = email;
+        this.name = name;
+        this.dailyGoalTime = dailyGoalTime;
+    }
+
+    public void updateFcmToken(String fcmToken){
+        this.fcmToken = fcmToken;
+    }
+
+    public void deleteFcmToken(){
+        this.fcmToken = null;
+    }
+}

--- a/snackpot-api/src/main/java/com/soma/member/entity/RoleType.java
+++ b/snackpot-api/src/main/java/com/soma/member/entity/RoleType.java
@@ -1,0 +1,12 @@
+package com.soma.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoleType {
+    GUEST("ROLE_GUEST"), USER("ROLE_USER");
+
+    private final String key;
+}

--- a/snackpot-api/src/main/java/com/soma/member/repository/MemberRepository.java
+++ b/snackpot-api/src/main/java/com/soma/member/repository/MemberRepository.java
@@ -1,0 +1,17 @@
+package com.soma.member.repository;
+
+import com.soma.common.constant.Status;
+import com.soma.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmailAndStatus(String email, Status status);
+
+    Boolean existsByName(String name);
+
+    Optional<Member> findByNameAndStatus(String name, Status status);
+
+    Optional<Member> findByIdAndStatus(Long id, Status status);
+}

--- a/snackpot-api/src/main/java/com/soma/notification/dto/request/MemberUpdateFcmTokenRequest.java
+++ b/snackpot-api/src/main/java/com/soma/notification/dto/request/MemberUpdateFcmTokenRequest.java
@@ -1,0 +1,12 @@
+package com.soma.notification.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberUpdateFcmTokenRequest {
+    private String fcmToken;
+}

--- a/snackpot-api/src/main/java/com/soma/notification/dto/request/SendManualReminderRequest.java
+++ b/snackpot-api/src/main/java/com/soma/notification/dto/request/SendManualReminderRequest.java
@@ -1,0 +1,12 @@
+package com.soma.notification.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SendManualReminderRequest {
+    private Long groupId; // 해당 회원의 그룹 ID
+}

--- a/snackpot-api/src/main/java/com/soma/notification/dto/response/MemberUpdateFcmTokenResponse.java
+++ b/snackpot-api/src/main/java/com/soma/notification/dto/response/MemberUpdateFcmTokenResponse.java
@@ -1,0 +1,19 @@
+package com.soma.notification.dto.response;
+
+import com.soma.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberUpdateFcmTokenResponse {
+    private Long id;
+    private String nickname;
+    private String fcmToken;
+
+    public static MemberUpdateFcmTokenResponse toDto(Member member) {
+        return new MemberUpdateFcmTokenResponse(member.getId(), member.getName(), member.getFcmToken());
+    }
+}

--- a/snackpot-api/src/main/java/com/soma/notification/service/FirebaseCloudMessageService.java
+++ b/snackpot-api/src/main/java/com/soma/notification/service/FirebaseCloudMessageService.java
@@ -1,0 +1,75 @@
+package com.soma.notification.service;
+
+import com.google.firebase.messaging.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class FirebaseCloudMessageService {
+    //private final FirebaseMessaging firebaseMessaging;
+
+    /**
+     * tokenList를 받아 여러 개의 기기로 알림 보내기
+     * @param tokenList 알림 보낼 fcmToken 리스트
+     * @param title 알림 메세지 제목
+     * @param body 알림 메세지 본문
+     */
+    public void sendByTokenList(List<String> tokenList, String title, String body) {
+
+        //여러기기에 메세지 전송
+        MulticastMessage multicastMessage = MulticastMessage.builder()
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .addAllTokens(tokenList)
+                .build();
+
+        try {
+            BatchResponse response = FirebaseMessaging.getInstance().sendMulticast(multicastMessage);
+            if (response.getFailureCount() > 0) {
+                List<SendResponse> responses = response.getResponses();
+                List<String> failedTokens = new ArrayList<>();
+                for (int i = 0; i < responses.size(); i++) {
+                    if (!responses.get(i).isSuccessful()) {
+                        failedTokens.add(tokenList.get(i));
+                    }
+                }
+                log.info("List of tokens that caused failures: {}", failedTokens);
+            }
+        } catch (FirebaseMessagingException e) {
+            log.info("FirebaseMessagingException: {}", e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * 하나의 token을 받아서, 한개의 기기로 알림 보내기
+     * @param token 알림 보낼 fcmToken
+     * @param title 알림 메세지 제목
+     * @param body 알림 메세지 본문
+     */
+    public void sendByToken(String token, String title, String body) {
+
+        // 메세지 만들기
+        Message message = Message.builder()
+                .setToken(token)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .build();
+
+        try {
+            FirebaseMessaging.getInstance().send(message);
+        } catch (FirebaseMessagingException e) {
+            log.info("FirebaseMessagingException: {}, fail token: {}", e.getMessage(), token);
+        }
+    }
+}

--- a/snackpot-api/src/main/java/com/soma/notification/service/NotificationService.java
+++ b/snackpot-api/src/main/java/com/soma/notification/service/NotificationService.java
@@ -1,0 +1,52 @@
+package com.soma.notification.service;
+
+
+import com.soma.exception.MemberNotFoundException;
+import com.soma.group.repository.GroupRepository;
+import com.soma.member.entity.Member;
+import com.soma.member.repository.MemberRepository;
+import com.soma.notification.dto.request.MemberUpdateFcmTokenRequest;
+import com.soma.notification.dto.request.SendManualReminderRequest;
+import com.soma.notification.dto.response.MemberUpdateFcmTokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.soma.common.constant.Status.ACTIVE;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class NotificationService {
+    private final MemberRepository memberRepository;
+    private final GroupRepository groupRepository;
+    private final FirebaseCloudMessageService firebaseCloudMessageService;
+
+    /**
+     * 로그인한 회원의 fcm 토큰을 저장합니다.
+     * @param request 회원의 fcm 토큰이 포함된 request
+     * @param email 로그인한 회원의 email
+     * @return
+     */
+    @Transactional
+    public MemberUpdateFcmTokenResponse updateFcmToken(MemberUpdateFcmTokenRequest request, String email){
+        Member member = memberRepository.findByEmailAndStatus(email, ACTIVE).orElseThrow(MemberNotFoundException::new);
+        member.updateFcmToken(request.getFcmToken());
+        return MemberUpdateFcmTokenResponse.toDto(member);
+    }
+
+    /**
+     * 로그인한 회원이 독촉하기 버튼을 클릭한 그룹의 현재 미션 수행중인 회원에게 독촉 푸시 알림을 전송합니다.
+     * @param request 독촉하기 버튼을 클릭한 그룹의 groupID가 포함된 requset
+     * @param email 로그인한 회원의 email
+     */
+//    public void sendManualReminderAlarm(SendManualReminderRequest request, String email) {
+//        // 그룹의 현재 미션 수행 중인 회원 조회
+//        Group group = groupRepository.findById(request.getGroupId()).orElseThrow(GroupNotFoundException::new);
+//        Member targetMember = memberRepository.findByIdAndStatus(group.getCurrentDoingMemberId(), ACTIVE).orElseThrow(MemberNotFoundException::new);
+//
+//        // 해당 회원에게 알림 전송
+//        Member member = memberRepository.findByEmailAndStatus(email, ACTIVE).orElseThrow(MemberNotFoundException::new);
+//        firebaseCloudMessageService.sendByToken(targetMember.getFcmToken(), MANUAL_REMINDER.getTitleWithNickname(member.getNickname()), MANUAL_REMINDER.getBody());
+//    }
+}

--- a/snackpot-api/src/main/java/com/soma/security/config/SecurityConfig.java
+++ b/snackpot-api/src/main/java/com/soma/security/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package com.soma.security.config;
+
+import com.soma.member.repository.MemberRepository;
+import com.soma.security.jwt.filter.JwtAuthenticationProcessingFilter;
+import com.soma.security.jwt.handler.JwtAccessDeniedHandler;
+import com.soma.security.jwt.service.JwtService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Slf4j
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final MemberRepository memberRepository;
+    private final JwtService jwtService;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .formLogin(formLogin -> formLogin.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .csrf(csrf -> csrf.disable())
+                .cors(withDefaults())
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(request -> request.requestMatchers(
+                                "/mvp/auth/login", "/mvp/auth/sign-up", "/error", "/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**", "/css/**", "/images/**", "/js/**", "/favicon.ico", "/h2-console/**",
+                                "/api/sign-up", "/api/auth/**", "/health", "missions/random/non-member", "/profiles").permitAll()
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .anyRequest().authenticated())
+                .addFilterAfter(jwtAuthenticationProcessingFilter(), LogoutFilter.class)
+                .exceptionHandling(exception -> exception.accessDeniedHandler(jwtAccessDeniedHandler));
+
+        return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationProcessingFilter jwtAuthenticationProcessingFilter() {
+        JwtAuthenticationProcessingFilter jwtAuthenticationProcessingFilter = new JwtAuthenticationProcessingFilter(jwtService, memberRepository);
+        return jwtAuthenticationProcessingFilter;
+    }
+}

--- a/snackpot-api/src/main/java/com/soma/security/jwt/PasswordUtil.java
+++ b/snackpot-api/src/main/java/com/soma/security/jwt/PasswordUtil.java
@@ -1,0 +1,29 @@
+package com.soma.security.jwt;
+
+import java.util.Random;
+
+public class PasswordUtil {
+    public static String generateRandomPassword() {
+        int index = 0;
+        char[] charSet = new char[] {
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+                'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+                'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+        };	//배열안의 문자 숫자는 원하는대로
+
+        StringBuffer password = new StringBuffer();
+        Random random = new Random();
+
+        for (int i = 0; i < 8 ; i++) {
+            double rd = random.nextDouble();
+            index = (int) (charSet.length * rd);
+
+            password.append(charSet[index]);
+        }
+        System.out.println(password);
+        return password.toString();
+        //StringBuffer를 String으로 변환해서 return 하려면 toString()을 사용하면 된다.
+    }
+}

--- a/snackpot-api/src/main/java/com/soma/security/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/snackpot-api/src/main/java/com/soma/security/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -1,0 +1,46 @@
+package com.soma.security.jwt.filter;
+
+import com.soma.member.repository.MemberRepository;
+import com.soma.security.jwt.service.JwtService;
+import com.soma.common.constant.Status;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/*
+Jwt 인증 필터 ("/login" 이외의 URI 요청이 왔을 때 처리하는 필터)
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
+    private static final Set<String> NO_CHECK_URLS = new HashSet<>(Arrays.asList("/login", "/api/auth/reissue", "/api/auth/logout"));
+
+    private final JwtService jwtService;
+    private final MemberRepository memberRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (NO_CHECK_URLS.stream().anyMatch(url -> url.equals(request.getRequestURI()))) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        log.info("JwtAuthenticationProcessingFilter 호출");
+        String accessToken = jwtService.extractAccessToken(request).orElse(null);
+
+        if (jwtService.isTokenValid(accessToken)) {
+            jwtService.extractEmail(accessToken)
+                    .ifPresent(email -> memberRepository.findByEmailAndStatus(email, Status.ACTIVE)
+                            .ifPresent(jwtService::saveAuthentication));
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/snackpot-api/src/main/java/com/soma/security/jwt/handler/JwtAccessDeniedHandler.java
+++ b/snackpot-api/src/main/java/com/soma/security/jwt/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,19 @@
+package com.soma.security.jwt.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+
+        response.sendError(HttpServletResponse.SC_FORBIDDEN); // 403에러
+    }
+}

--- a/snackpot-api/src/main/java/com/soma/security/jwt/service/JwtService.java
+++ b/snackpot-api/src/main/java/com/soma/security/jwt/service/JwtService.java
@@ -1,0 +1,138 @@
+package com.soma.security.jwt.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.soma.member.entity.Member;
+import com.soma.member.entity.RoleType;
+import com.soma.member.repository.MemberRepository;
+import com.soma.security.jwt.PasswordUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.Optional;
+
+@Getter
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class JwtService {
+
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+
+    @Value("${jwt.access.expiration}")
+    private Integer accessTokenExpirationPeriod;
+
+    @Value("${jwt.refresh.expiration}")
+    private Integer refreshTokenExpirationPeriod;
+
+    @Value("${jwt.access.header}")
+    private String accessHeader;
+
+    @Value("${jwt.refresh.header}")
+    private String refreshHeader;
+
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+    private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
+    private static final String EMAIL_CLAIM = "email";
+    private static final String BEARER = "Bearer ";
+
+    private final MemberRepository memberRepository;
+    private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    public String createAccessToken(String email) {
+        Date now = new Date();
+
+        return JWT.create()
+                .withSubject(ACCESS_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
+                .withClaim(EMAIL_CLAIM, email)
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
+    public String createRefreshToken(String email) {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject(REFRESH_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + refreshTokenExpirationPeriod))
+                .withClaim(EMAIL_CLAIM, email)
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
+    /*
+    헤더에서 AccessToken 추출
+     */
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(accessHeader))
+                .filter(accessToken -> accessToken.startsWith(BEARER))
+                .map(accessToken -> accessToken.replace(BEARER, ""));
+    }
+
+    /*
+    AccessToken에서 Email 추출
+     */
+    public Optional<String> extractEmail(String token) {
+        try {
+            // 토큰 유효성 검사하는 데에 사용할 알고리즘이 있는 JWT verifier builder 반환
+            return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
+                    .build()
+                    .verify(token)
+                    .getClaim(EMAIL_CLAIM)
+                    .asString());
+        } catch (Exception e) {
+            log.error("토큰이 유효하지 않습니다.");
+            return Optional.empty();
+        }
+    }
+
+    /*
+    토큰의 유효성 검사
+     */
+    public boolean isTokenValid(String token) {
+        try {
+            JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
+
+            return true;
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            e.printStackTrace();
+            log.info("잘못된 JWT 토큰입니다.");
+        }
+        return false;
+    }
+
+    public void saveAuthentication(Member myMember) {
+        log.info("JwtService.saveAuthentication() 호출");
+        String password = myMember.getPassword();
+
+        if (password == null) {
+            password = PasswordUtil.generateRandomPassword();
+        }
+
+        UserDetails userDetailsUser = User.builder()
+                .username(myMember.getEmail())
+                .password(password)
+                .roles(RoleType.USER.name())
+                .build();
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetailsUser, null,
+                authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/snackpot-api/src/main/java/com/soma/util/response/Failure.java
+++ b/snackpot-api/src/main/java/com/soma/util/response/Failure.java
@@ -1,0 +1,10 @@
+package com.soma.util.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Failure implements Result{
+    private String message;
+}

--- a/snackpot-api/src/main/java/com/soma/util/response/Response.java
+++ b/snackpot-api/src/main/java/com/soma/util/response/Response.java
@@ -1,0 +1,28 @@
+package com.soma.util.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.soma.advice.ErrorCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@JsonInclude(JsonInclude.Include.NON_NULL) // null 값을 가지는 필드는 제외
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter // 응답 객체를 JSON으로 변환하기 위해 필요
+public class Response {
+    private Boolean success;
+    private int code;
+    private Result result;
+
+    public static Response success() {
+        return new Response(true, 0, null);
+    }
+
+    public static <T> Response success(T data) {
+        return new Response(true, 0, new Success<>(data));
+    }
+
+    public static Response failure(ErrorCode errorCode) {
+        return new Response(false, errorCode.getCode(), new Failure(errorCode.getMessage()));
+    }
+}

--- a/snackpot-api/src/main/java/com/soma/util/response/Result.java
+++ b/snackpot-api/src/main/java/com/soma/util/response/Result.java
@@ -1,0 +1,4 @@
+package com.soma.util.response;
+
+public interface Result {
+}

--- a/snackpot-api/src/main/java/com/soma/util/response/Success.java
+++ b/snackpot-api/src/main/java/com/soma/util/response/Success.java
@@ -1,0 +1,10 @@
+package com.soma.util.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Success<T> implements Result {
+    private T data;
+}

--- a/snackpot-api/src/main/resources/application.yml
+++ b/snackpot-api/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  profiles:
+    group:
+      local-env:
+        - local
+      dev-env:
+        - dev
+      prod-blue-env:
+        - prod
+        - blue
+      prod-green-env:
+        - prod
+        - green
+    include:
+      - jwt
+      - oauth
+      - fcm
+      - sentry

--- a/snackpot-common/src/main/java/com/soma/SnackpotCommonApplication.java
+++ b/snackpot-common/src/main/java/com/soma/SnackpotCommonApplication.java
@@ -2,8 +2,10 @@ package com.soma;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+//@EnableJpaAuditing
 public class SnackpotCommonApplication {
 
     public static void main(String[] args) {

--- a/snackpot-common/src/main/java/com/soma/common/BaseEntity.java
+++ b/snackpot-common/src/main/java/com/soma/common/BaseEntity.java
@@ -1,0 +1,20 @@
+package com.soma.common;
+
+import com.soma.common.constant.Status;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public class BaseEntity extends BaseTimeEntity{
+    @Enumerated(EnumType.STRING)
+    private Status status; // 상태 (INACTIVE = 삭제)
+    public void inActive() {
+        this.status = Status.INACTIVE;
+    }
+    public void active(){
+        this.status = Status.ACTIVE;
+    }
+}

--- a/snackpot-common/src/main/java/com/soma/common/BaseTimeEntity.java
+++ b/snackpot-common/src/main/java/com/soma/common/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.soma.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public void updateCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/snackpot-common/src/main/java/com/soma/common/constant/Status.java
+++ b/snackpot-common/src/main/java/com/soma/common/constant/Status.java
@@ -1,0 +1,5 @@
+package com.soma.common.constant;
+
+public enum Status {
+    ACTIVE, INACTIVE
+}

--- a/snackpot-common/src/main/java/com/soma/exercise/entity/Exercise.java
+++ b/snackpot-common/src/main/java/com/soma/exercise/entity/Exercise.java
@@ -1,0 +1,48 @@
+package com.soma.exercise.entity;
+
+import com.soma.youtuber.entity.Youtuber;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Exercise {
+    // todo : 시퀀스 생각해보기
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Youtuber youtuber;
+
+    private String videoId;
+
+    private Integer calories;
+
+    @Enumerated(EnumType.STRING)
+    private Level level;
+
+    private String effective;
+
+    private String title;
+
+    private String thumbnail;
+
+    private Integer timeSpent;
+
+    @Builder
+    public Exercise(Youtuber youtuber, String videoId, Integer calories, Level level, String effective, String title, String thumbnail, Integer timeSpent) {
+        this.youtuber = youtuber;
+        this.videoId = videoId;
+        this.calories = calories;
+        this.level = level;
+        this.effective = effective;
+        this.title = title;
+        this.thumbnail = thumbnail;
+        this.timeSpent = timeSpent;
+    }
+}

--- a/snackpot-common/src/main/java/com/soma/exercise/entity/Exercise.java
+++ b/snackpot-common/src/main/java/com/soma/exercise/entity/Exercise.java
@@ -26,7 +26,7 @@ public class Exercise {
     @Enumerated(EnumType.STRING)
     private Level level;
 
-    private String effective;
+    private String effect;
 
     private String title;
 
@@ -35,12 +35,12 @@ public class Exercise {
     private Integer timeSpent;
 
     @Builder
-    public Exercise(Youtuber youtuber, String videoId, Integer calories, Level level, String effective, String title, String thumbnail, Integer timeSpent) {
+    public Exercise(Youtuber youtuber, String videoId, Integer calories, Level level, String effect, String title, String thumbnail, Integer timeSpent) {
         this.youtuber = youtuber;
         this.videoId = videoId;
         this.calories = calories;
         this.level = level;
-        this.effective = effective;
+        this.effect = effect;
         this.title = title;
         this.thumbnail = thumbnail;
         this.timeSpent = timeSpent;

--- a/snackpot-common/src/main/java/com/soma/exercise/entity/Level.java
+++ b/snackpot-common/src/main/java/com/soma/exercise/entity/Level.java
@@ -1,0 +1,14 @@
+package com.soma.exercise.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Level {
+    EASY("쉬움"),
+    MEDIUM("보통"),
+    HARD("어려움");
+
+    private final String levelType;
+}

--- a/snackpot-common/src/main/java/com/soma/exercise/repository/ExerciseRepository.java
+++ b/snackpot-common/src/main/java/com/soma/exercise/repository/ExerciseRepository.java
@@ -1,0 +1,7 @@
+package com.soma.exercise.repository;
+
+import com.soma.exercise.entity.Exercise;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
+}

--- a/snackpot-common/src/main/java/com/soma/youtuber/entity/Youtuber.java
+++ b/snackpot-common/src/main/java/com/soma/youtuber/entity/Youtuber.java
@@ -1,0 +1,23 @@
+package com.soma.youtuber.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Youtuber {
+    @Id
+    private Long id;
+
+    private String channelId;
+
+    private String description;
+
+    private String name;
+
+    private String profileImg;
+}

--- a/snackpot-common/src/main/java/com/soma/youtuber/repository/YoutuberRepository.java
+++ b/snackpot-common/src/main/java/com/soma/youtuber/repository/YoutuberRepository.java
@@ -1,0 +1,7 @@
+package com.soma.youtuber.repository;
+
+import com.soma.youtuber.entity.Youtuber;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface YoutuberRepository extends JpaRepository<Youtuber, Long> {
+}


### PR DESCRIPTION
## 지라 이슈
[SNK-68](https://soma-tall-i.atlassian.net/jira/software/projects/SNK/boards/2?selectedIssue=SNK-68)

## 작업사항
- 공통 모듈인 snackpot-common에는 batch 모듈과 api 모듈에 사용될 Exercise와 Youtuber 도메인을 작성했습니다.
- api 모듈인 snackpot-api에는 회원가입/로그인 및 Security 설정과 JWT 인증 관련 로직을 작성했습니다.

## 이야기 할 내용
- 모듈간의 역할을 분리하는데 고민을 많이 했던 것 같습니다. 이부분을 참고해주시면 감사하겠습니다~

[SNK-68]: https://soma-tall-i.atlassian.net/browse/SNK-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ