### PR TITLE
[SNK-48] 그룹 생성하기 API 개발

### DIFF
--- a/snackpot-api/src/main/java/com/soma/advice/ExceptionAdvice.java
+++ b/snackpot-api/src/main/java/com/soma/advice/ExceptionAdvice.java
@@ -1,10 +1,25 @@
 package com.soma.advice;
 
+import com.soma.exception.MemberNotFoundException;
+import com.soma.util.response.Response;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static com.soma.advice.ErrorCode.MEMBER_NOT_FOUND_EXCEPTION;
 
 @Getter
 @RequiredArgsConstructor
+@RestControllerAdvice
 public class ExceptionAdvice {
+    @ExceptionHandler(MemberNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Response MemberNotFoundExceptionHandler(MemberNotFoundException e){
+//        Sentry.captureException(e);
+        return Response.failure(MEMBER_NOT_FOUND_EXCEPTION);
+    }
 
 }

--- a/snackpot-api/src/main/java/com/soma/auth/service/AuthService.java
+++ b/snackpot-api/src/main/java/com/soma/auth/service/AuthService.java
@@ -9,6 +9,7 @@ import com.soma.common.constant.Status;
 import com.soma.exception.MemberNicknameAlreadyExistsException;
 import com.soma.exception.MemberNotFoundException;
 import com.soma.member.entity.Member;
+import com.soma.member.entity.RoleType;
 import com.soma.member.repository.MemberRepository;
 import com.soma.notification.service.NotificationService;
 import com.soma.security.jwt.service.JwtService;
@@ -35,6 +36,7 @@ public class AuthService {
                 .email(email)
                 .name(request.getName())
                 .dailyGoalTime(request.getDailyGoalTime())
+                .roleType(RoleType.USER)
                 .build();
         // fcm 토큰 저장
         member.updateFcmToken(request.getFcmToken());

--- a/snackpot-api/src/main/java/com/soma/group/controller/GroupController.java
+++ b/snackpot-api/src/main/java/com/soma/group/controller/GroupController.java
@@ -1,15 +1,29 @@
 package com.soma.group.controller;
 
+import com.soma.group.dto.request.GroupCreateRequest;
+import com.soma.group.service.GroupService;
+import com.soma.util.response.Response;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @Tag(name = "Exgroup", description = "운동 그룹 API")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/groups")
 public class GroupController {
+    private final GroupService groupService;
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping()
+    public Response create(@RequestBody GroupCreateRequest request, @AuthenticationPrincipal UserDetails loginUser){
+        return Response.success(groupService.create(request, loginUser.getUsername()));
+    }
 
 }
 

--- a/snackpot-api/src/main/java/com/soma/group/dto/request/GroupCreateRequest.java
+++ b/snackpot-api/src/main/java/com/soma/group/dto/request/GroupCreateRequest.java
@@ -1,7 +1,27 @@
 package com.soma.group.dto.request;
 
+import com.soma.group.entity.Group;
+import com.soma.group.entity.GroupCode;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.time.LocalDate;
 
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
 public class GroupCreateRequest {
+    @NotBlank(message = "그룹 이름은 필수입니다.")
     private String groupName;
+
+
+    public Group toEntity(LocalDate startDate) {
+        return Group.builder()
+                .name(groupName)
+                .code(GroupCode.create6Number())
+                .startDate(startDate)
+                .build();
+    }
 }

--- a/snackpot-api/src/main/java/com/soma/group/dto/response/GroupCreateResponse.java
+++ b/snackpot-api/src/main/java/com/soma/group/dto/response/GroupCreateResponse.java
@@ -1,0 +1,15 @@
+package com.soma.group.dto.response;
+
+import com.soma.group.entity.Group;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class GroupCreateResponse {// todo: 인텔리제이가 record 타입으로 변경 추천
+    private final String groupName;
+    public static GroupCreateResponse toDto(Group group){
+        return new GroupCreateResponse(group.getName());
+    }
+
+}

--- a/snackpot-api/src/main/java/com/soma/group/dto/response/GroupResponse.java
+++ b/snackpot-api/src/main/java/com/soma/group/dto/response/GroupResponse.java
@@ -1,7 +1,13 @@
 package com.soma.group.dto.response;
 
+import com.soma.group.entity.Group;
+import lombok.Builder;
+import lombok.Getter;
+
 import java.time.LocalDate;
 
+@Builder
+@Getter
 public class GroupResponse {
     private Long id;
 
@@ -10,4 +16,15 @@ public class GroupResponse {
     private LocalDate startDate; // 시작 기간
 
     private String code; // 그룹 입장 코드
+
+
+    public static GroupResponse toDto(Group group){
+        return GroupResponse.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .startDate(group.getStartDate())
+                .code(group.getCode())
+                .build();
+    }
+
 }

--- a/snackpot-api/src/main/java/com/soma/group/service/GroupService.java
+++ b/snackpot-api/src/main/java/com/soma/group/service/GroupService.java
@@ -1,4 +1,37 @@
 package com.soma.group.service;
 
+import com.soma.common.constant.Status;
+import com.soma.exception.MemberNotFoundException;
+import com.soma.group.dto.request.GroupCreateRequest;
+import com.soma.group.dto.response.GroupCreateResponse;
+import com.soma.group.entity.Group;
+import com.soma.group.repository.GroupRepository;
+import com.soma.joinlist.entity.JoinList;
+import com.soma.joinlist.repository.JoinListRepository;
+import com.soma.member.entity.Member;
+import com.soma.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
 public class GroupService {
+    private final GroupRepository groupRepository;
+    private final JoinListRepository joinListRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public GroupCreateResponse create(GroupCreateRequest request, String email) {
+        Group group = request.toEntity(LocalDate.now());
+        groupRepository.save(group);
+        Member member = memberRepository.findByEmailAndStatus(email, Status.ACTIVE).orElseThrow(MemberNotFoundException::new);
+        joinListRepository.save(JoinList.createHostJoinList(member, group));
+        return GroupCreateResponse.toDto(group);
+    }
 }

--- a/snackpot-api/src/main/java/com/soma/security/config/SecurityConfig.java
+++ b/snackpot-api/src/main/java/com/soma/security/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(request -> request.requestMatchers(
                                 "/mvp/auth/login", "/mvp/auth/sign-up", "/error", "/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**", "/css/**", "/images/**", "/js/**", "/favicon.ico", "/h2-console/**",
-                                "/api/sign-up", "/api/auth/**", "/health", "missions/random/non-member", "/profiles").permitAll()
+                                "/auth/**", "/health", "missions/random/non-member", "/profiles").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilterAfter(jwtAuthenticationProcessingFilter(), LogoutFilter.class)

--- a/snackpot-api/src/main/resources/application.yml
+++ b/snackpot-api/src/main/resources/application.yml
@@ -16,3 +16,37 @@ spring:
       - oauth
       - fcm
       - sentry
+
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+
+#  h2:
+#    console:
+#      enabled: true
+#      path: /h2-console
+#
+#  datasource:
+#    driver-class-name: org.h2.Driver
+#    url: jdbc:h2:tcp://localhost/./snackpot;MODE=MySQL;
+#    username: SA
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  sql:
+    init:
+      mode: never
+
+logging:
+  level:
+    #    org.springframework.orm.jpa: DEBUG
+    #    org.springframework.transaction: DEBUG
+    org.springframework.test.context.transaction: DEBUG # test시, 트랜잭션 시작 종료 로그 확인을 위해

--- a/snackpot-api/src/test/java/com/soma/group/controller/GroupControllerAdviceTest.java
+++ b/snackpot-api/src/test/java/com/soma/group/controller/GroupControllerAdviceTest.java
@@ -1,0 +1,70 @@
+package com.soma.group.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.soma.advice.ExceptionAdvice;
+import com.soma.exception.MemberNotFoundException;
+import com.soma.group.dto.request.GroupCreateRequest;
+import com.soma.group.factory.dto.GroupCreateFactory;
+import com.soma.group.service.GroupService;
+import com.soma.security.TestUserArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static com.soma.advice.ErrorCode.MEMBER_NOT_FOUND_EXCEPTION;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class GroupControllerAdviceTest {
+    @InjectMocks
+    private GroupController groupController;
+    @Mock
+    GroupService groupService;
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(groupController)
+                .setCustomArgumentResolvers(new TestUserArgumentResolver())
+                .setControllerAdvice(new ExceptionAdvice())
+//                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+
+
+    @Test
+    @DisplayName("운동 그룹 생성 시, MemberNotFoundException가 발생했을 때 적절한 오류 메시지를 반환한다.")
+    void MemberNotFoundExceptionTest() throws Exception {
+        //given
+        GroupCreateRequest request = GroupCreateFactory.createGroupCreateRequest();
+        when(groupService.create(any(), anyString())).thenThrow(MemberNotFoundException.class);
+
+        //when //then
+        mockMvc.perform(
+                        post("/groups")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+
+                )
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(MEMBER_NOT_FOUND_EXCEPTION.getCode()))
+                .andExpect(jsonPath("$.result.message").value(MEMBER_NOT_FOUND_EXCEPTION.getMessage()))
+                .andDo(print());
+    }
+
+}

--- a/snackpot-api/src/test/java/com/soma/group/controller/GroupControllerIntegrationTest.java
+++ b/snackpot-api/src/test/java/com/soma/group/controller/GroupControllerIntegrationTest.java
@@ -1,0 +1,84 @@
+package com.soma.group.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.soma.group.dto.request.GroupCreateRequest;
+import com.soma.group.repository.GroupRepository;
+import com.soma.member.factory.entity.MemberFactory;
+import com.soma.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import static com.soma.group.factory.dto.GroupCreateFactory.createGroupCreateRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@DisplayName("GroupController 통합 테스트")
+public class GroupControllerIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+    @Autowired
+    private GroupRepository groupRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+//    @Autowired
+//    private TestInitDB initDB;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+//                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .apply(springSecurity())
+                .build();
+
+        // security 인증 정보를 제공하기 위한 유저 정보 저장
+        memberRepository.save(MemberFactory.createUserRoleMember());
+    }
+
+
+    @Test
+    @DisplayName("그룹 이름을 입력해 그룹을 생성한다.")
+    @WithMockUser(username = "test@naver.com")
+    void createTest() throws Exception {
+        //given
+        GroupCreateRequest request = createGroupCreateRequest();
+        int beforeSize = groupRepository.findAll().size();
+
+        //when //then
+        mockMvc.perform(
+                post("/groups")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                ).andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value("true"))
+                .andExpect(jsonPath("$.code").value("0"))
+                .andExpect(jsonPath("$.result.data.groupName").value(request.getGroupName()))
+                .andDo(print());
+
+        int afterSize = groupRepository.findAll().size();
+        assertThat(afterSize).isEqualTo(beforeSize + 1);
+    }
+}

--- a/snackpot-api/src/test/java/com/soma/group/controller/GroupControllerIntegrationTest.java
+++ b/snackpot-api/src/test/java/com/soma/group/controller/GroupControllerIntegrationTest.java
@@ -5,6 +5,7 @@ import com.soma.group.dto.request.GroupCreateRequest;
 import com.soma.group.repository.GroupRepository;
 import com.soma.member.factory.entity.MemberFactory;
 import com.soma.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/snackpot-api/src/test/java/com/soma/group/controller/GroupControllerTest.java
+++ b/snackpot-api/src/test/java/com/soma/group/controller/GroupControllerTest.java
@@ -1,0 +1,71 @@
+package com.soma.group.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.soma.group.dto.request.GroupCreateRequest;
+import com.soma.group.dto.response.GroupCreateResponse;
+import com.soma.group.factory.dto.GroupCreateFactory;
+import com.soma.group.service.GroupService;
+import com.soma.member.factory.fixtures.MemberFixtures;
+import com.soma.security.TestUserArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupController 단위 테스트")
+class GroupControllerTest {
+    @InjectMocks
+    private GroupController groupController;
+    @Mock
+    GroupService groupService;
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(groupController)
+                .setCustomArgumentResolvers(new TestUserArgumentResolver())
+//                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+
+    @Test
+    @DisplayName("그룹 이름을 입력해 그룹을 생성한다.")
+    void create() throws Exception {
+        //given
+        GroupCreateRequest request = GroupCreateFactory.createGroupCreateRequest();
+        GroupCreateResponse response = new GroupCreateResponse(request.getGroupName());
+//        when(groupService.create(request, MemberFixtures.이메일)).thenReturn(response); // todo 왜 이건 안되는거지....?
+        when(groupService.create(any(), eq(MemberFixtures.이메일))).thenReturn(response);
+
+        //when //then
+        mockMvc.perform(
+                post("/groups")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+
+                )
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value("true"))
+                .andExpect(jsonPath("$.code").value("0"))
+                .andExpect(jsonPath("$.result.data.groupName").value(request.getGroupName()))
+                .andDo(print());
+    }
+
+
+}

--- a/snackpot-api/src/test/java/com/soma/group/factory/dto/GroupCreateFactory.java
+++ b/snackpot-api/src/test/java/com/soma/group/factory/dto/GroupCreateFactory.java
@@ -1,0 +1,9 @@
+package com.soma.group.factory.dto;
+
+import com.soma.group.dto.request.GroupCreateRequest;
+
+public class GroupCreateFactory {
+    public static GroupCreateRequest createGroupCreateRequest(){
+        return new GroupCreateRequest("테스트 그룹");
+    }
+}

--- a/snackpot-api/src/test/java/com/soma/group/service/GroupServiceTest.java
+++ b/snackpot-api/src/test/java/com/soma/group/service/GroupServiceTest.java
@@ -1,0 +1,52 @@
+package com.soma.group.service;
+
+import com.soma.group.dto.request.GroupCreateRequest;
+import com.soma.group.dto.response.GroupCreateResponse;
+import com.soma.group.repository.GroupRepository;
+import com.soma.joinlist.repository.JoinListRepository;
+import com.soma.member.factory.fixtures.MemberFixtures;
+import com.soma.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.soma.group.factory.dto.GroupCreateFactory.createGroupCreateRequest;
+import static com.soma.member.factory.entity.MemberFactory.createUserRoleMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GroupService 비즈니스 로직 테스트")
+class GroupServiceTest {
+    @InjectMocks
+    private GroupService groupService;
+
+    @Mock
+    private GroupRepository groupRepository;
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private JoinListRepository joinListRepository;
+    @DisplayName("그룹 이름을 입력해 그룹을 생성한다.")
+    @Test
+    void create() throws Exception {
+        //given
+        GroupCreateRequest request = createGroupCreateRequest();
+
+        //mocking
+        given(memberRepository.findByEmailAndStatus(anyString(), any())).willReturn(Optional.of(createUserRoleMember()));
+
+        // when
+        GroupCreateResponse response = groupService.create(request, MemberFixtures.이메일);
+
+        // then
+        assertThat(response.getGroupName()).isEqualTo(request.getGroupName());
+    }
+}

--- a/snackpot-api/src/test/java/com/soma/member/factory/entity/MemberFactory.java
+++ b/snackpot-api/src/test/java/com/soma/member/factory/entity/MemberFactory.java
@@ -1,0 +1,20 @@
+package com.soma.member.factory.entity;
+
+import com.soma.member.entity.Member;
+
+import static com.soma.member.factory.fixtures.MemberFixtures.*;
+
+public class MemberFactory {
+
+    public static Member createUserRoleMember(){
+        return Member.builder()
+                .name(이름)
+                .dailyGoalTime(하루목표운동시간)
+                .email(이메일)
+                .profileImg(프로필사진)
+                .password(비밀번호)
+                .roleType(일반권한)
+                .fcmToken(FCM토큰)
+                .build();
+    }
+}

--- a/snackpot-api/src/test/java/com/soma/member/factory/fixtures/MemberFixtures.java
+++ b/snackpot-api/src/test/java/com/soma/member/factory/fixtures/MemberFixtures.java
@@ -1,0 +1,17 @@
+package com.soma.member.factory.fixtures;
+
+import com.soma.member.entity.RoleType;
+
+import static com.soma.member.entity.RoleType.*;
+
+public class MemberFixtures {
+    public static String 이름 = "김누구";
+    public static Integer 하루목표운동시간 = 10;
+    public static String 이메일 = "test@naver.com";
+    public static String 프로필사진 = "profile_image";
+    public static String 비밀번호 = "password";
+    public static RoleType 일반권한 = USER;
+    public static RoleType 게스트권한 = GUEST;
+    public static String FCM토큰 = "sample_fcm_token";
+
+}

--- a/snackpot-api/src/test/java/com/soma/security/TestUserArgumentResolver.java
+++ b/snackpot-api/src/test/java/com/soma/security/TestUserArgumentResolver.java
@@ -1,0 +1,29 @@
+package com.soma.security;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+// https://stackoverflow.com/questions/38330597/inject-authenticationprincipal-when-unit-testing-a-spring-rest-controller
+
+public class TestUserArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(UserDetails.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        UserDetails userDetails = mock(UserDetails.class);
+        given(userDetails.getUsername()).willReturn("test@naver.com");
+        return userDetails;
+    }
+}
+
+

--- a/snackpot-domain/src/main/java/com/soma/SnackpotCommonApplication.java
+++ b/snackpot-domain/src/main/java/com/soma/SnackpotCommonApplication.java
@@ -1,9 +1,8 @@
 package com.soma;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+//@SpringBootApplication // 테스트 실행 시, 에러 발생에 따라 주석 처리 [Error] Found multiple @SpringBootConfiguration annotated classes
 //@EnableJpaAuditing
 public class SnackpotCommonApplication {
     public static void main(String[] args) {

--- a/snackpot-domain/src/main/java/com/soma/group/entity/Group.java
+++ b/snackpot-domain/src/main/java/com/soma/group/entity/Group.java
@@ -2,10 +2,7 @@ package com.soma.group.entity;
 
 import com.soma.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 
@@ -24,4 +21,14 @@ public class Group extends BaseEntity {
     private LocalDate startDate; // 시작 기간
 
     private String code; // 그룹 입장 코드
+
+    @Builder
+    public Group(String name, LocalDate startDate, String code) {
+        this.name = name;
+        this.startDate = startDate;
+        this.code = code;
+        active();
+    }
+
+
 }

--- a/snackpot-domain/src/main/java/com/soma/group/entity/GroupCode.java
+++ b/snackpot-domain/src/main/java/com/soma/group/entity/GroupCode.java
@@ -1,0 +1,17 @@
+package com.soma.group.entity;
+
+import java.util.Random;
+
+public class GroupCode {
+    private static Random random = new Random();
+    private static int leftLimit = 48; // numeral '0'
+    private static int rightLimit = 57; // numeral '9'
+    private static int targetStringLength = 6;
+
+    public static String create6Number(){
+        return random.ints(leftLimit, rightLimit + 1)
+                .limit(targetStringLength)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+    }
+}

--- a/snackpot-domain/src/main/java/com/soma/joinlist/entity/JoinList.java
+++ b/snackpot-domain/src/main/java/com/soma/joinlist/entity/JoinList.java
@@ -3,10 +3,9 @@ package com.soma.joinlist.entity;
 import com.soma.group.entity.Group;
 import com.soma.member.entity.Member;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import static com.soma.joinlist.entity.JoinType.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -25,4 +24,28 @@ public class JoinList {
 
     @Enumerated(EnumType.STRING)
     private JoinType joinType;
+
+    @Builder
+    public JoinList(Member member, Group group, JoinType joinType) {
+        this.member = member;
+        this.group = group;
+        this.joinType = joinType;
+    }
+
+    public static JoinList createHostJoinList(Member member, Group group){
+        return JoinList.builder()
+                .member(member)
+                .group(group)
+                .joinType(HOST)
+                .build();
+    }
+
+    public static JoinList createMemberJoinList(Member member, Group group){
+        return JoinList.builder()
+                .member(member)
+                .group(group)
+                .joinType(HOST)
+                .build();
+    }
+
 }

--- a/snackpot-domain/src/main/java/com/soma/joinlist/repository/JoinListRepository.java
+++ b/snackpot-domain/src/main/java/com/soma/joinlist/repository/JoinListRepository.java
@@ -1,0 +1,7 @@
+package com.soma.joinlist.repository;
+
+import com.soma.joinlist.entity.JoinList;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JoinListRepository extends JpaRepository<JoinList, Long>{
+}

--- a/snackpot-domain/src/main/java/com/soma/member/entity/Member.java
+++ b/snackpot-domain/src/main/java/com/soma/member/entity/Member.java
@@ -29,10 +29,15 @@ public class Member extends BaseEntity {
     private RoleType roleType;
 
     @Builder
-    public Member(String email, String name, Integer dailyGoalTime) {
-        this.email = email;
+    public Member(String name, String email, Integer dailyGoalTime, String profileImg, String fcmToken, String password, RoleType roleType) {
         this.name = name;
+        this.email = email;
         this.dailyGoalTime = dailyGoalTime;
+        this.profileImg = profileImg;
+        this.fcmToken = fcmToken;
+        this.password = password;
+        this.roleType = roleType;
+        active();
     }
 
     public void updateFcmToken(String fcmToken){


### PR DESCRIPTION
## 지라 이슈
- [SNK-48](https://soma-tall-i.atlassian.net/jira/software/projects/SNK/boards/2?selectedIssue=SNK-48)

## 작업사항
- 그룹 생성 API 개발
  그룹 이름을 입력하여, 그룹을 생성할 수 있습니다. 그룹을 생성한 사람은 그룹의 리더가 됩니다.

- 테스트 코드 작성
    - 그룹 생성 controller 단위 테스트, 통합 테스트
    - 그룹 생성 service 단위 테스트
    - MemberNotFoundException Handler 단위 테스트
    
   수정사항 발생 시, 다른 로직에 영향이 있는지 쉽게 판단할 수 있도록 controller, service에 대해서 단위 테스트 및 통합 테스트를 작성하였습니다. repository는 기본적으로 JpaRepository에서 생성한 것만 사용하여 단위 테스트를 작성하지 않았습니다.
  
## 이야기 할 내용
- 추후, request DTO에 대해 @NotNull, @NotBlank 등의 validation 처리를 진행하도록 하겠습니다.

[SNK-48]: https://soma-tall-i.atlassian.net/browse/SNK-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ