### PR TITLE
[SNK-71] startDateCursor 삭제 및 서브쿼리로 대체

### DIFF
--- a/snackpot-api/src/main/java/com/soma/domain/group/controller/GroupController.java
+++ b/snackpot-api/src/main/java/com/soma/domain/group/controller/GroupController.java
@@ -36,11 +36,8 @@ public class GroupController {
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping()
-    public Response readAll(@RequestParam(required = false) Long groupIdCursor, @RequestParam(required = false) LocalDate startDateCursor, @RequestParam(defaultValue = "5") Integer size, @AuthenticationPrincipal UserDetails loginUser){
-        System.out.println("groupIdCursor = " + groupIdCursor);
-        System.out.println("startDateCursor = " + startDateCursor);
-
-        return Response.success(groupService.readAll(groupIdCursor, startDateCursor, size, loginUser.getUsername()));
+    public Response readAll(@RequestParam(required = false) Long groupIdCursor, @RequestParam(defaultValue = "5") Integer size, @AuthenticationPrincipal UserDetails loginUser){
+        return Response.success(groupService.readAll(groupIdCursor, size, loginUser.getUsername()));
     }
 
 }

--- a/snackpot-api/src/main/java/com/soma/domain/group/repository/GroupRepositoryCustom.java
+++ b/snackpot-api/src/main/java/com/soma/domain/group/repository/GroupRepositoryCustom.java
@@ -10,6 +10,6 @@ import org.springframework.data.domain.Slice;
 import java.time.LocalDate;
 
 public interface GroupRepositoryCustom {
-    Slice<GroupListResponse> findAllByCursor(Member member, Long groupIdCursor, LocalDate startDateCursor, Pageable pageable);
+    Slice<GroupListResponse> findAllByCursor(Member member, Long groupIdCursor, Pageable pageable);
     Slice<GroupListResponse> findFirstGroupList(Member member, Pageable pageable);
 }

--- a/snackpot-api/src/main/java/com/soma/domain/group/service/GroupService.java
+++ b/snackpot-api/src/main/java/com/soma/domain/group/service/GroupService.java
@@ -55,12 +55,12 @@ public class GroupService {
         return GroupNameResponse.toDto(group);
     }
 
-    public Slice<GroupListResponse> readAll(Long groupIdCursor, LocalDate startDateCursor, Integer size, String email) {
+    public Slice<GroupListResponse> readAll(Long groupIdCursor, Integer size, String email) {
         Member member = memberRepository.findByEmailAndStatus(email, Status.ACTIVE).orElseThrow(MemberNotFoundException::new);
-        if (groupIdCursor == null && startDateCursor == null){
+        if (groupIdCursor == null){
             return groupRepository.findFirstGroupList(member, PageRequest.of(0, size));
         }else{
-            return groupRepository.findAllByCursor(member, groupIdCursor, startDateCursor, PageRequest.of(0, size));
+            return groupRepository.findAllByCursor(member, groupIdCursor, PageRequest.of(0, size));
         }
     }
 }

--- a/snackpot-api/src/test/java/com/soma/domain/group/repository/GroupRepositoryCustomImplTest.java
+++ b/snackpot-api/src/test/java/com/soma/domain/group/repository/GroupRepositoryCustomImplTest.java
@@ -72,7 +72,7 @@ class GroupRepositoryCustomImplTest {
 
 
         //when
-        Slice<GroupListResponse> allByCursor = groupRepository.findAllByCursor(사용자A, 그룹D.getId(), LocalDate.of(2023, 9, 3), PageRequest.of(0, 2));
+        Slice<GroupListResponse> allByCursor = groupRepository.findAllByCursor(사용자A, 그룹D.getId(), PageRequest.of(0, 2));
 
         //then
         assertThat(allByCursor.getContent()).hasSize(2)
@@ -116,7 +116,7 @@ class GroupRepositoryCustomImplTest {
 
 
         //when
-        Slice<GroupListResponse> allByCursor = groupRepository.findAllByCursor(사용자A, 그룹B.getId(), LocalDate.of(2023, 9, 3), PageRequest.of(0, 2));
+        Slice<GroupListResponse> allByCursor = groupRepository.findAllByCursor(사용자A, 그룹B.getId(), PageRequest.of(0, 2));
 
         //then
         assertThat(allByCursor.getContent()).hasSize(1)


### PR DESCRIPTION
## 지라 이슈
- [SNK-71](https://soma-tall-i.atlassian.net/jira/software/projects/SNK/boards/2?selectedIssue=SNK-71)

## 작업사항
- 추후 날짜 외에 다른 정렬 기준이 사용되어 커서가 변경될 수 있기에, groupId만 커서로 사용하기로 수정하였습니다. (진서님 리뷰 감사합니다 ㅎㅎ)
- 커서(groupId)를 사용해서 날짜를 서브쿼리로 조회하도록 수정하였습니다.


[SNK-71]: https://soma-tall-i.atlassian.net/browse/SNK-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ