### PR TITLE
[SNK-76] 그룹 일주일 운동 시간 통계 조회 API

### DIFF
--- a/snackpot-api/src/main/java/com/soma/domain/exercise_record/repository/ExerciseRecordRepository.java
+++ b/snackpot-api/src/main/java/com/soma/domain/exercise_record/repository/ExerciseRecordRepository.java
@@ -2,6 +2,16 @@ package com.soma.domain.exercise_record.repository;
 
 import com.soma.domain.exercise_record.entity.ExerciseRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface ExerciseRecordRepository extends JpaRepository<ExerciseRecord, Long> {
+
+    @Query("select er from ExerciseRecord er join fetch er.member " +
+            "join JoinList  j on er.member = j.member and j.group.id = :groupId and :startDate <= er.createdAt AND er.createdAt < :endDate " +
+            "order by er.createdAt desc")
+    List<ExerciseRecord> findWeekExerciseTimeStatics(@Param("groupId") Long groupId, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 }

--- a/snackpot-api/src/main/java/com/soma/domain/group/controller/GroupController.java
+++ b/snackpot-api/src/main/java/com/soma/domain/group/controller/GroupController.java
@@ -43,6 +43,12 @@ public class GroupController {
     public Response readAllAbsentees(@PathVariable Long groupId, @AuthenticationPrincipal UserDetails loginUser){
         return Response.success(groupService.readAllAbsentees(groupId));
     }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/{groupId}/statistics")
+    public Response readExerciseTimeStatics(@PathVariable Long groupId, @AuthenticationPrincipal UserDetails loginUser){
+        return Response.success(groupService.readExerciseTimeStatics(groupId));
+    }
 }
 
 

--- a/snackpot-api/src/main/java/com/soma/domain/group/dto/response/GroupTimeStaticsResponse.java
+++ b/snackpot-api/src/main/java/com/soma/domain/group/dto/response/GroupTimeStaticsResponse.java
@@ -1,0 +1,22 @@
+package com.soma.domain.group.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class GroupTimeStaticsResponse {
+    private String day;
+    private LocalDate date;
+    private List<UserTimeStaticsResponse> statics;
+
+    public static GroupTimeStaticsResponse toDto(LocalDate date, List<UserTimeStaticsResponse> userTimeStaticsResponseList) {
+        return new GroupTimeStaticsResponse(date.getDayOfWeek().name().toLowerCase().substring(0, 3),
+                date,
+                userTimeStaticsResponseList);
+    }
+
+}

--- a/snackpot-api/src/main/java/com/soma/domain/group/dto/response/UserTimeStaticsResponse.java
+++ b/snackpot-api/src/main/java/com/soma/domain/group/dto/response/UserTimeStaticsResponse.java
@@ -1,0 +1,21 @@
+package com.soma.domain.group.dto.response;
+
+import com.soma.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class UserTimeStaticsResponse {
+    private Long userId;
+    private String name;
+    private int time;
+
+    public static UserTimeStaticsResponse toDto(Member member, int time){
+        return new UserTimeStaticsResponse(member.getId(), member.getName(), time);
+    }
+
+    public void add(int time){
+        this.time += time;
+    }
+}

--- a/snackpot-api/src/main/java/com/soma/domain/group/service/GroupService.java
+++ b/snackpot-api/src/main/java/com/soma/domain/group/service/GroupService.java
@@ -1,12 +1,11 @@
 package com.soma.domain.group.service;
 
 import com.soma.common.constant.Status;
+import com.soma.domain.exercise_record.entity.ExerciseRecord;
 import com.soma.domain.exercise_record.repository.ExerciseRecordRepository;
 import com.soma.domain.group.dto.request.GroupCreateRequest;
 import com.soma.domain.group.dto.request.GroupJoinRequest;
-import com.soma.domain.group.dto.response.GroupAbsenteeResponse;
-import com.soma.domain.group.dto.response.GroupListResponse;
-import com.soma.domain.group.dto.response.GroupNameResponse;
+import com.soma.domain.group.dto.response.*;
 import com.soma.domain.group.entity.Group;
 import com.soma.domain.group.repository.GroupRepository;
 import com.soma.domain.joinlist.entity.JoinList;
@@ -25,7 +24,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -76,5 +79,46 @@ public class GroupService {
         LocalDateTime today = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0);// 오늘 자정 구일하기
         LocalDateTime nextDay = today.plusDays(1);// 내일 자정 구하기
         return joinListRepository.findAllAbsenteesByGroupId(groupId, today, nextDay).stream().map(GroupAbsenteeResponse::toDto).toList();
+    }
+
+    public Object readExerciseTimeStatics(Long groupId) {
+        if(!groupRepository.existsById(groupId)){
+            throw new GroupNotFoundException();
+        }
+        LocalDateTime startDate = getStartLocalDateTimeOfWeek();
+        LocalDateTime endDate = getEndLocalDateTimeOfWeek();
+        List<ExerciseRecord> result = exerciseRecordRepository.findWeekExerciseTimeStatics(groupId, startDate, endDate);
+        List<Member> members = joinListRepository.findAllMembersByGroupId(groupId);
+
+        Map<LocalDate, Map<Member, UserTimeStaticsResponse>> map = new HashMap<>();
+        for(int i=0; i<7; i++){
+            LocalDate localDate = startDate.plusDays(i).toLocalDate();
+            map.put(localDate,
+                    members.stream().collect(Collectors.toMap(member -> member, member -> UserTimeStaticsResponse.toDto(member, 0))));
+        }
+
+        for (ExerciseRecord exerciseRecord : result) {
+            map.get(exerciseRecord.getCreatedAt().toLocalDate()).get(exerciseRecord.getMember()).add(exerciseRecord.getTime());
+        }
+
+        List<GroupTimeStaticsResponse> response = new ArrayList<>();
+        for(int i=0; i<7; i++) {
+            LocalDate localDate = startDate.plusDays(i).toLocalDate();
+            response.add(GroupTimeStaticsResponse.toDto(localDate, map.get(localDate).values().stream().toList()));
+        }
+
+        return response;
+    }
+
+    private LocalDateTime getStartLocalDateTimeOfWeek(){
+        LocalDateTime today = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0);// 오늘 자정
+        int dayOfWeek = today.getDayOfWeek().getValue(); // 오늘 요일(숫자), 월(1), 일(7)
+        return today.minusDays(dayOfWeek-1).withHour(0).withMinute(0).withSecond(0).withNano(0);
+    }
+
+    private LocalDateTime getEndLocalDateTimeOfWeek(){
+        LocalDateTime today = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0);// 오늘 자정
+        int dayOfWeek = today.getDayOfWeek().getValue(); // 오늘 요일(숫자), 월(1), 일(7)
+        return today.plusDays(8-dayOfWeek).withHour(0).withMinute(0).withSecond(0).withNano(0);
     }
 }

--- a/snackpot-api/src/main/java/com/soma/domain/group/service/GroupService.java
+++ b/snackpot-api/src/main/java/com/soma/domain/group/service/GroupService.java
@@ -81,7 +81,7 @@ public class GroupService {
         return joinListRepository.findAllAbsenteesByGroupId(groupId, today, nextDay).stream().map(GroupAbsenteeResponse::toDto).toList();
     }
 
-    public Object readExerciseTimeStatics(Long groupId) {
+    public List<GroupTimeStaticsResponse> readExerciseTimeStatics(Long groupId) {
         if(!groupRepository.existsById(groupId)){
             throw new GroupNotFoundException();
         }

--- a/snackpot-api/src/main/java/com/soma/domain/joinlist/repository/JoinListRepository.java
+++ b/snackpot-api/src/main/java/com/soma/domain/joinlist/repository/JoinListRepository.java
@@ -16,4 +16,7 @@ public interface JoinListRepository extends JpaRepository<JoinList, Long>{
     @Query("select j.member from JoinList j left join ExerciseRecord er on j.member = er.member and :startDateTime <= er.createdAt AND er.createdAt < :endDateTime " +
             "where j.group.id = :groupId and er.id is null")
     List<Member> findAllAbsenteesByGroupId(@Param("groupId") Long groupId, @Param("startDateTime") LocalDateTime startDateTime, @Param("endDateTime") LocalDateTime endDateTime);
+
+    @Query("select j.member from JoinList j where j.group.id = :groupId and j.status = 'ACTIVE'")
+    List<Member> findAllMembersByGroupId(@Param("groupId") Long groupId);
 }

--- a/snackpot-api/src/test/java/com/soma/domain/exercise_record/factory/entity/ExerciseRecordFactory.java
+++ b/snackpot-api/src/test/java/com/soma/domain/exercise_record/factory/entity/ExerciseRecordFactory.java
@@ -9,6 +9,15 @@ public class ExerciseRecordFactory {
         return ExerciseRecord.builder()
                 .exercise(exercise)
                 .member(member)
+                .time(10)
+                .build();
+    }
+
+    public static ExerciseRecord createExerciseRecordWithExerciseAndMemberAndTime(Exercise exercise, Member member, Integer time){
+        return ExerciseRecord.builder()
+                .exercise(exercise)
+                .member(member)
+                .time(time)
                 .build();
     }
 }

--- a/snackpot-api/src/test/java/com/soma/domain/group/controller/GroupControllerIntegrationTest.java
+++ b/snackpot-api/src/test/java/com/soma/domain/group/controller/GroupControllerIntegrationTest.java
@@ -306,6 +306,11 @@ public class GroupControllerIntegrationTest {
         기록B.updateCreatedAt(수);
         기록D.updateCreatedAt(일);
 
+        List<Member> all = memberRepository.findAll();
+        for (Member member : all) {
+            System.out.println("member = " + member.getName() + ", " + member.getId());
+        }
+
         //when //then
         mockMvc.perform(
                         get("/groups/{groupId}/statistics", 그룹.getId())
@@ -318,17 +323,17 @@ public class GroupControllerIntegrationTest {
                 .andExpect(jsonPath("$.result.data[0].date").value("2023-09-25"))
                 .andExpect(jsonPath("$.result.data[0].statics", hasSize(4)))
                 .andExpect(jsonPath("$.result.data[0].statics", Matchers.containsInAnyOrder(
-                        Map.of("userId", 2, "name", "회원A", "time",  10), // todo: 회원A.getId()로 하면 에러 발생함
-                        Map.of("userId", 3, "name", "회원B", "time", 0),
-                        Map.of("userId", 4, "name", "회원C", "time", 0),
-                        Map.of("userId", 5, "name", "회원D", "time", 0))))
+                        Map.of("userId", 회원A.getId().intValue(), "name", "회원A", "time",  10), // todo: 회원A.getId()로 하면 에러 발생함
+                        Map.of("userId", 회원B.getId().intValue(), "name", "회원B", "time", 0),
+                        Map.of("userId", 회원C.getId().intValue(), "name", "회원C", "time", 0),
+                        Map.of("userId", 회원D.getId().intValue(), "name", "회원D", "time", 0))))
                 .andExpect(jsonPath("$.result.data[6].day").value("sun"))
                 .andExpect(jsonPath("$.result.data[6].date").value("2023-10-01"))
                 .andExpect(jsonPath("$.result.data[6].statics", Matchers.containsInAnyOrder(
-                        Map.of("userId", 2, "name", "회원A", "time",  0), // todo: 회원A.getId()로 하면 에러 발생함
-                        Map.of("userId", 3, "name", "회원B", "time", 0),
-                        Map.of("userId", 4, "name", "회원C", "time", 0),
-                        Map.of("userId", 5, "name", "회원D", "time", 30))))
+                        Map.of("userId", 회원A.getId().intValue(), "name", "회원A", "time",  0), // todo: 회원A.getId()로 하면 에러 발생함 - 회원A.getId().intValue()는 테스트 통과... 왜지?
+                        Map.of("userId", 회원B.getId().intValue(), "name", "회원B", "time", 0),
+                        Map.of("userId", 회원C.getId().intValue(), "name", "회원C", "time", 0),
+                        Map.of("userId", 회원D.getId().intValue(), "name", "회원D", "time", 30))))
                 .andDo(print());
     }
 

--- a/snackpot-api/src/test/java/com/soma/domain/group/controller/GroupControllerIntegrationTest.java
+++ b/snackpot-api/src/test/java/com/soma/domain/group/controller/GroupControllerIntegrationTest.java
@@ -306,11 +306,6 @@ public class GroupControllerIntegrationTest {
         기록B.updateCreatedAt(수);
         기록D.updateCreatedAt(일);
 
-        List<Member> all = memberRepository.findAll();
-        for (Member member : all) {
-            System.out.println("member = " + member.getName() + ", " + member.getId());
-        }
-
         //when //then
         mockMvc.perform(
                         get("/groups/{groupId}/statistics", 그룹.getId())


### PR DESCRIPTION
## 지라 이슈
- [SNK-76](https://soma-tall-i.atlassian.net/jira/software/projects/SNK/boards/2?selectedIssue=SNK-76)

## 작업사항
- 그룹 일주일 운동 시간 통계 조회 API를 생성했습니다.
- ExerciseRecord의 Entity에 createdAt이 LocalDateTime으로 저장되어있어, repository단에서 group by createdAt을 사용하여 날짜별, 회원의 운동시간 총합을 구해오지 못했습니다. 따라서 ExerciseRecord를 전부 가져와 Java Code로 총합을 구했습니다.

## 이야기 할 내용
- 해당 방법이 최선의 방법인지는 의문이 듭니다.
- 혹시 Service 단의 코드를 보시고 쉽게 이해가 되지 않으시는지 궁금합니다.


[SNK-76]: https://soma-tall-i.atlassian.net/browse/SNK-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ