### PR TITLE
[SNK-74] 오늘 운동 미수행 사용자 목록 조회 API - response에 groupCode 필드 추가

### DIFF
--- a/snackpot-api/src/main/java/com/soma/domain/group/dto/response/GroupAbsenteeResponse.java
+++ b/snackpot-api/src/main/java/com/soma/domain/group/dto/response/GroupAbsenteeResponse.java
@@ -1,16 +1,17 @@
 package com.soma.domain.group.dto.response;
 
-import com.soma.domain.member.entity.Member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.List;
 
 @AllArgsConstructor
 @Getter
 public class GroupAbsenteeResponse {
-    private String name;
-    private String profileImage;
+    private String groupCode;
+    private List<GroupAbsenteeUser> absentees;
 
-    public static GroupAbsenteeResponse toDto(Member member){
-        return new GroupAbsenteeResponse(member.getName(), member.getProfileImg());
+    public static GroupAbsenteeResponse toDto(String groupCode, List<GroupAbsenteeUser> absentees){
+        return new GroupAbsenteeResponse(groupCode, absentees);
     }
 }

--- a/snackpot-api/src/main/java/com/soma/domain/group/dto/response/GroupAbsenteeUser.java
+++ b/snackpot-api/src/main/java/com/soma/domain/group/dto/response/GroupAbsenteeUser.java
@@ -1,0 +1,16 @@
+package com.soma.domain.group.dto.response;
+
+import com.soma.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class GroupAbsenteeUser {
+    private String name;
+    private String profileImage;
+
+    public static GroupAbsenteeUser toDto(Member member){
+        return new GroupAbsenteeUser(member.getName(), member.getProfileImg());
+    }
+}

--- a/snackpot-api/src/main/java/com/soma/domain/group/service/GroupService.java
+++ b/snackpot-api/src/main/java/com/soma/domain/group/service/GroupService.java
@@ -72,13 +72,11 @@ public class GroupService {
         }
     }
 
-    public List<GroupAbsenteeResponse> readAllAbsentees(Long groupId) {
-        if(!groupRepository.existsById(groupId)){
-            throw new GroupNotFoundException();
-        }
+    public GroupAbsenteeResponse readAllAbsentees(Long groupId) {
+        Group group = groupRepository.findById(groupId).orElseThrow(GroupNotFoundException::new);
         LocalDateTime today = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0);// 오늘 자정 구일하기
         LocalDateTime nextDay = today.plusDays(1);// 내일 자정 구하기
-        return joinListRepository.findAllAbsenteesByGroupId(groupId, today, nextDay).stream().map(GroupAbsenteeResponse::toDto).toList();
+        return GroupAbsenteeResponse.toDto(group.getCode(), joinListRepository.findAllAbsenteesByGroupId(groupId, today, nextDay).stream().map(GroupAbsenteeUser::toDto).toList());
     }
 
     public List<GroupTimeStaticsResponse> readExerciseTimeStatics(Long groupId) {

--- a/snackpot-api/src/test/java/com/soma/domain/group/controller/GroupControllerIntegrationTest.java
+++ b/snackpot-api/src/test/java/com/soma/domain/group/controller/GroupControllerIntegrationTest.java
@@ -263,7 +263,8 @@ public class GroupControllerIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value("true"))
                 .andExpect(jsonPath("$.code").value("0"))
-                .andExpect(jsonPath("$.result.data", Matchers.containsInAnyOrder(
+                .andExpect(jsonPath("$.result.data.groupCode").value(그룹.getCode()))
+                .andExpect(jsonPath("$.result.data.absentees", Matchers.containsInAnyOrder(
                         Map.of("name", "회원B", "profileImage", MemberFixtures.프로필사진),
                         Map.of("name", "회원C", "profileImage", MemberFixtures.프로필사진),
                         Map.of("name", "회원D", "profileImage", MemberFixtures.프로필사진))))


### PR DESCRIPTION
## 지라 이슈
- [SNK-74](https://soma-tall-i.atlassian.net/jira/software/projects/SNK/boards/2?selectedIssue=SNK-74)

## 작업사항
- 프론트 요청사항에 따라 오늘 운동 미수행 사용자 목록 조회의 response에 groupCode 필드를 추가하였습니다.


[SNK-74]: https://soma-tall-i.atlassian.net/browse/SNK-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ