### PR TITLE
[SNK-75] 그룹 운동 수행 결과 표 조회 API

### DIFF
--- a/snackpot-api/src/main/java/com/soma/domain/exercise_record/dto/CheckList.java
+++ b/snackpot-api/src/main/java/com/soma/domain/exercise_record/dto/CheckList.java
@@ -1,0 +1,5 @@
+package com.soma.domain.exercise_record.dto;
+
+public enum CheckList {
+    CHECK, UNCHECK, PARTIAL
+}

--- a/snackpot-api/src/main/java/com/soma/domain/exercise_record/dto/response/ExerciseCheckListResponse.java
+++ b/snackpot-api/src/main/java/com/soma/domain/exercise_record/dto/response/ExerciseCheckListResponse.java
@@ -1,0 +1,49 @@
+package com.soma.domain.exercise_record.dto.response;
+
+import com.soma.domain.exercise_record.dto.CheckList;
+import com.soma.domain.group.dto.response.UserTimeStaticsResponse;
+import com.soma.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.soma.domain.exercise_record.dto.CheckList.*;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class ExerciseCheckListResponse {
+    private String userName;
+    private Long userId;
+    private List<CheckList> checkList;
+    private Integer successNum; // 일주일 중 성공한 횟수
+    public static ExerciseCheckListResponse toDto(Member member){
+        return ExerciseCheckListResponse.builder()
+                .userId(member.getId())
+                .userName(member.getName())
+                .checkList(new ArrayList<>(Collections.nCopies(7, UNCHECK)))
+                .successNum(7)
+                .build();
+    }
+
+    public void updateCheckList(Member member, LocalDate localDate, UserTimeStaticsResponse userTimeStaticsResponse) {
+        int idx = localDate.getDayOfWeek().getValue()-1;
+        if(userTimeStaticsResponse.getTime() == 0) {
+            checkList.set(idx, UNCHECK);
+        }else if(member.getDailyGoalTime() > userTimeStaticsResponse.getTime()){
+            checkList.set(idx, PARTIAL);
+        }else {
+            checkList.set(idx, CHECK);
+        }
+    }
+
+    public void updateSuccessNum(){
+        successNum = Collections.frequency(checkList, CHECK);
+    }
+}

--- a/snackpot-api/src/main/java/com/soma/domain/group/controller/GroupController.java
+++ b/snackpot-api/src/main/java/com/soma/domain/group/controller/GroupController.java
@@ -62,6 +62,14 @@ public class GroupController {
     public Response readExerciseTimeStatics(@PathVariable(value = "groupId") Long groupId, @AuthenticationPrincipal UserDetails loginUser){
         return Response.success(groupService.readExerciseTimeStatics(groupId));
     }
+
+    @Operation(summary = "그룹 일주일 운동 수행 결과표 조회", description = "그룹 일주일 운동 수행 결과표를 조회합니다.", security = { @SecurityRequirement(name = "Authorization") })
+    @Parameter(name = "groupId", description = "운동 그룹 ID",  required = true,  in = ParameterIn.PATH)
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/{groupId}/checklist")
+    public Response readExerciseCheckList(@PathVariable(value = "groupId") Long groupId, @AuthenticationPrincipal UserDetails loginUser){
+        return Response.success(groupService.readExerciseCheckList(groupId));
+    }
 }
 
 

--- a/snackpot-api/src/test/java/com/soma/domain/member/factory/entity/MemberFactory.java
+++ b/snackpot-api/src/test/java/com/soma/domain/member/factory/entity/MemberFactory.java
@@ -30,4 +30,16 @@ public class MemberFactory {
                 .fcmToken(FCM토큰)
                 .build();
     }
+
+    public static Member createUserRoleMemberWithNameAndEmailAndDailyGoalTime(String name, String email, Integer dailyGoalTime){
+        return Member.builder()
+                .name(name)
+                .dailyGoalTime(dailyGoalTime)
+                .email(email)
+                .profileImg(프로필사진)
+                .password(비밀번호)
+                .roleType(일반권한)
+                .fcmToken(FCM토큰)
+                .build();
+    }
 }


### PR DESCRIPTION
## 지라 이슈
- [SNK-75](https://soma-tall-i.atlassian.net/jira/software/projects/SNK/boards/2?selectedIssue=SNK-75)

## 작업사항
- 그룹 운동 수행 결과 표 조회 API를 구현했습니다.
- 연속일 수를 위한 코드가 생각보다 어려워서 우선은 일주일 중 성공횟수를 반환하도록 구현하였습니다.

## 이야기 할 내용
- 연속일 수 계산을 위해서는 현재 ERD 구조상으로는 해당 그룹의 해당 그룹원의 모든 운동 기록 데이터를 가져와서 최신날짜부터 끊기지 않고 연속 며칠 운동했는지 코드를 작성해야할 것 같은데요...! 이전 프로젝트에서도 성능 이슈가 발생하기 전까지는 역정규화는 하지 않는 방향이 좋겠다고 이야기 나눴던 것 같아요! 그래도 왠지 매번 많은 양의 데이터를 조회하는게 비효율적인 것 같아 고민이 되네요...ㅎㅎㅎ 혹시 좋은 구현 방법 생각 나신다면 공유 부탁해주시면 감사하겠습니다!


[SNK-75]: https://soma-tall-i.atlassian.net/browse/SNK-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ