### PR TITLE
[SNK-72] 그룹 삭제 API

### DIFF
--- a/snackpot-api/src/main/java/com/soma/domain/group/controller/GroupController.java
+++ b/snackpot-api/src/main/java/com/soma/domain/group/controller/GroupController.java
@@ -62,6 +62,15 @@ public class GroupController {
     public Response readExerciseTimeStatics(@PathVariable(value = "groupId") Long groupId, @AuthenticationPrincipal UserDetails loginUser){
         return Response.success(groupService.readExerciseTimeStatics(groupId));
     }
+
+    @Operation(summary = "그룹 삭제", description = "그룹을 삭제합니다.", security = { @SecurityRequirement(name = "Authorization") })
+    @Parameter(name = "groupId", description = "운동 그룹 ID",  required = true,  in = ParameterIn.PATH)
+    @ResponseStatus(HttpStatus.OK)
+    @DeleteMapping("/{groupId}")
+    public Response delete(@PathVariable(value = "groupId") Long groupId, @AuthenticationPrincipal UserDetails loginUser){
+        groupService.delete(groupId);
+        return Response.success();
+    }
 }
 
 

--- a/snackpot-api/src/main/java/com/soma/domain/group/service/GroupService.java
+++ b/snackpot-api/src/main/java/com/soma/domain/group/service/GroupService.java
@@ -121,4 +121,11 @@ public class GroupService {
         int dayOfWeek = today.getDayOfWeek().getValue(); // 오늘 요일(숫자), 월(1), 일(7)
         return today.plusDays(8-dayOfWeek).withHour(0).withMinute(0).withSecond(0).withNano(0);
     }
+
+    @Transactional
+    public void delete(Long groupId) {
+        joinListRepository.deleteAllInBatch(joinListRepository.findAllByGroupId(groupId));
+        Group group = groupRepository.findById(groupId).orElseThrow(GroupNotFoundException::new);
+        groupRepository.delete(group);
+    }
 }

--- a/snackpot-api/src/main/java/com/soma/domain/joinlist/repository/JoinListRepository.java
+++ b/snackpot-api/src/main/java/com/soma/domain/joinlist/repository/JoinListRepository.java
@@ -19,4 +19,6 @@ public interface JoinListRepository extends JpaRepository<JoinList, Long>{
 
     @Query("select j.member from JoinList j where j.group.id = :groupId and j.status = 'ACTIVE'")
     List<Member> findAllMembersByGroupId(@Param("groupId") Long groupId);
+
+    List<JoinList> findAllByGroupId(Long groupId);
 }

--- a/snackpot-api/src/test/java/com/soma/domain/group/controller/GroupControllerIntegrationTest.java
+++ b/snackpot-api/src/test/java/com/soma/domain/group/controller/GroupControllerIntegrationTest.java
@@ -47,8 +47,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -330,6 +329,47 @@ public class GroupControllerIntegrationTest {
                         Map.of("userId", 회원C.getId().intValue(), "name", "회원C", "time", 0),
                         Map.of("userId", 회원D.getId().intValue(), "name", "회원D", "time", 30))))
                 .andDo(print());
+    }
+
+    @Test
+    @DisplayName("그룹을 삭제한다.")
+    @WithMockUser(username = "test@naver.com")
+    void deleteGroupTest() throws Exception {
+        //given
+        Group 그룹 = GroupFactory.createGroup();
+        groupRepository.save(그룹);
+
+        Member 회원A = MemberFactory.createUserRoleMemberWithNameAndEmail("회원A", "A@gmail.com");
+        Member 회원B = MemberFactory.createUserRoleMemberWithNameAndEmail("회원B", "B@gmail.com");
+        Member 회원C = MemberFactory.createUserRoleMemberWithNameAndEmail("회원C", "C@gmail.com");
+        Member 회원D = MemberFactory.createUserRoleMemberWithNameAndEmail("회원D", "D@gmail.com");
+        memberRepository.saveAll(List.of(회원A, 회원B, 회원C, 회원D));
+
+        joinListRepository.save(JoinListFactory.createHostJoinList(회원A, 그룹));
+        joinListRepository.save(JoinListFactory.createMemberJoinList(회원B, 그룹));
+        joinListRepository.save(JoinListFactory.createMemberJoinList(회원C, 그룹));
+        joinListRepository.save(JoinListFactory.createMemberJoinList(회원D, 그룹));
+
+        int beforeJoinListSize = joinListRepository.findAll().size();
+        int beforeGroupSize = groupRepository.findAll().size();
+        int beforeMemberSize = memberRepository.findAll().size();
+
+        //when //then
+        mockMvc.perform(
+                        delete("/groups/{groupId}", 그룹.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value("true"))
+                .andExpect(jsonPath("$.code").value("0"))
+                .andDo(print());
+
+        int afterJoinListSize = joinListRepository.findAll().size();
+        int afterGroupSize = groupRepository.findAll().size();
+        int afterMemberSize = memberRepository.findAll().size();
+        assertThat(afterJoinListSize).isEqualTo(0);
+        assertThat(afterGroupSize).isEqualTo(0);
+        assertThat(afterMemberSize).isEqualTo(5);
     }
 
 }


### PR DESCRIPTION
## 지라 이슈
- [SNK-72](https://soma-tall-i.atlassian.net/jira/software/projects/SNK/boards/2?selectedIssue=SNK-72)

## 작업사항
- 그룹 삭제 API를 구현하였습니다.
- 그룹 삭제시 그룹이 외래키로 설정된 JoinList에서도 해당 그룹과 관련된 모든 데이터를 삭제하였습니다.
- 삭제하는 과정에서 개별 element에 대해서 delete함수를 호출해 여러개의 delete 쿼리가 실행되는 deleteAll 대신 여러개의 element를 where절의 or로 묶어서 하나의 delete 쿼리를 실행하는 deleteAllInBatch를 사용하였습니다.
- 삭제한 그룹을 복구할 가능성이 없을 것 같아, status를 INACTIVE로 처리하는 대신 실제로 삭제하였습니다.


## 이야기 할 내용
- 혹시라도 발생할 고객분들의 복구나 요구사항을 확인하기 위해서 실제로 데이터를 삭제하는 것이 아닌, INACTIVE 처리하는 것이 나을까요? 해당 내용을 개인정보처리방침에 명시만 한다면 개인정보처리방침상 위반은 아닌 듯 합니다!
[참고블로그](https://velog.io/@hipiction/First-Project-soft-delete-VS-hard-delete)


[SNK-72]: https://soma-tall-i.atlassian.net/browse/SNK-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ