### PR TITLE
[SNK-78] 운동 리스트 조회 쿼리 바인딩 문제 해결

### DIFF
--- a/snackpot-api/src/main/java/com/soma/domain/exercise/dto/response/ExerciseResponse.java
+++ b/snackpot-api/src/main/java/com/soma/domain/exercise/dto/response/ExerciseResponse.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @AllArgsConstructor
@@ -17,8 +18,23 @@ public class ExerciseResponse {
     private String title;
     private String youtuberName;
     private Integer timeSpent;
-    private List<BodyPartType> bodyPartTypes;
+    private List<BodyPartType> bodyPartTypes = new ArrayList<>();
     private Level level;
     private Integer calories;
     private Boolean isLiked;
+
+    public ExerciseResponse(Long exerciseId, String thumbnail, String title, String youtuberName, Integer timeSpent, Integer calories, Level level, Boolean isLiked) {
+        this.exerciseId = exerciseId;
+        this.thumbnail = thumbnail;
+        this.title = title;
+        this.youtuberName = youtuberName;
+        this.timeSpent = timeSpent;
+        this.calories = calories;
+        this.level = level;
+        this.isLiked = isLiked;
+    }
+
+    public void updateBodyPartTypes(List<BodyPartType> bodyPartTypes) {
+        this.bodyPartTypes = bodyPartTypes;
+    }
 }

--- a/snackpot-api/src/test/java/com/soma/domain/exercise/controller/ExerciseControllerIntegrationTest.java
+++ b/snackpot-api/src/test/java/com/soma/domain/exercise/controller/ExerciseControllerIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.soma.domain.exercise.controller;
+
+import com.soma.domain.exercise.entity.Exercise;
+import com.soma.domain.exercise.factory.entity.ExerciseFactory;
+import com.soma.domain.exercise.repository.ExerciseRepository;
+import com.soma.domain.member.entity.Member;
+import com.soma.domain.member.factory.entity.MemberFactory;
+import com.soma.domain.member.repository.MemberRepository;
+import com.soma.domain.youtuber.entity.Youtuber;
+import com.soma.domain.youtuber.factory.entity.YoutuberFactory;
+import com.soma.domain.youtuber.repository.YoutuberRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@DisplayName("ExerciseLikeController 통합 테스트")
+class ExerciseControllerIntegrationTest {
+    @Autowired private MockMvc mockMvc;
+
+    @Autowired private WebApplicationContext context;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private ExerciseRepository exerciseRepository;
+    @Autowired private YoutuberRepository youtuberRepository;
+
+    private Member 회원;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+
+        회원 = memberRepository.save(MemberFactory.createUserRoleMember());
+    }
+
+    @Test
+    @DisplayName("운동 목록 리스트를 조회한다.")
+    @WithMockUser(username = "test@naver.com")
+    void readAllByConditionTest() throws Exception {
+        //given
+        Youtuber 유튜버 = YoutuberFactory.createYoutuber();
+        youtuberRepository.save(유튜버);
+
+        Exercise 운동 = exerciseRepository.save(ExerciseFactory.createExerciseWithYoutuber(유튜버));
+        exerciseRepository.save(운동);
+
+        clean();
+
+        //when, then
+        mockMvc.perform(
+                        get("/exercises")
+                                .param("size", "1")
+                ).andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value("true"))
+                .andExpect(jsonPath("$.code").value("0"))
+                .andDo(print());
+    }
+
+
+
+    void clean() {
+        em.flush();
+        em.clear();
+    }
+}


### PR DESCRIPTION
## 지라 이슈
- SNK-78(https://soma-tall-i.atlassian.net/jira/software/projects/SNK/boards/2?selectedIssue=SNK-78)

## 작업사항
- querydsl Projections.fields에서 ExerciseResponse의 List 필드에 바인딩이 지원되지 않아 쿼리를 두 부분으로 나누었습니다.
- isLiked 좋아요 여부를 회원, 비회원 여부에 따라 분기 해주었습니다. 