### PR TITLE
[SNK-78] 운동 목록 조회 시 운동 종류 속성 ResponseDto에 추가

### DIFF
--- a/snackpot-api/src/main/java/com/soma/domain/exercise/dto/response/ExerciseResponse.java
+++ b/snackpot-api/src/main/java/com/soma/domain/exercise/dto/response/ExerciseResponse.java
@@ -1,6 +1,7 @@
 package com.soma.domain.exercise.dto.response;
 
 import com.soma.domain.bodypart.entity.BodyPartType;
+import com.soma.domain.exercise.entity.ExerciseType;
 import com.soma.domain.exercise.entity.Level;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,8 +23,9 @@ public class ExerciseResponse {
     private Level level;
     private Integer calories;
     private Boolean isLiked;
+    private ExerciseType exerciseType;
 
-    public ExerciseResponse(Long exerciseId, String thumbnail, String title, String youtuberName, Integer timeSpent, Integer calories, Level level, Boolean isLiked) {
+    public ExerciseResponse(Long exerciseId, String thumbnail, String title, String youtuberName, Integer timeSpent, Integer calories, Level level, Boolean isLiked, ExerciseType exerciseType) {
         this.exerciseId = exerciseId;
         this.thumbnail = thumbnail;
         this.title = title;
@@ -32,6 +34,7 @@ public class ExerciseResponse {
         this.calories = calories;
         this.level = level;
         this.isLiked = isLiked;
+        this.exerciseType = exerciseType;
     }
 
     public void updateBodyPartTypes(List<BodyPartType> bodyPartTypes) {

--- a/snackpot-api/src/main/java/com/soma/domain/exercise/repository/ExerciseRepositoryImpl.java
+++ b/snackpot-api/src/main/java/com/soma/domain/exercise/repository/ExerciseRepositoryImpl.java
@@ -48,7 +48,8 @@ public class ExerciseRepositoryImpl implements ExerciseRepositoryCustom {
                         exercise.timeSpent,
                         exercise.calories,
                         exercise.level,
-                        isLikedExpression
+                        isLikedExpression,
+                        exercise.exerciseType
                 ))
                 .from(exercise)
                 .leftJoin(youtuber).on(exercise.youtuber.id.eq(youtuber.id));


### PR DESCRIPTION
## 지라 이슈
- [SNK-78](https://soma-tall-i.atlassian.net/jira/software/projects/SNK/boards/2?selectedIssue=SNK-78)

## 작업사항
- 운동 엔티티에 운동 종류 필드가 추가됨에 따라서 운동 목록 조회시에도 각 운동마다 운동 종류까지 조회되도록 Response Dto를 변경하였습니다.

[SNK-78]: https://soma-tall-i.atlassian.net/browse/SNK-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ