### PR TITLE
[SNK-98] 회원가입시 이름 중복 등록 문제 해결

### DIFF
--- a/snackpot-api/src/main/java/com/soma/advice/ErrorCode.java
+++ b/snackpot-api/src/main/java/com/soma/advice/ErrorCode.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
     /* Member */
     MEMBER_NOT_FOUND_EXCEPTION(-1100, "사용자가 존재하지 않습니다."),
+    MEMBER_ALREADY_EXIST(-1101, "이미 해당 이름을 가진 사용자가 존재합니다."),
 
     /* Group */
     ALREADY_JOINED_GROUP_EXCEPTION(-1200, "이미 가입한 그룹입니다."),

--- a/snackpot-api/src/main/java/com/soma/advice/ExceptionAdvice.java
+++ b/snackpot-api/src/main/java/com/soma/advice/ExceptionAdvice.java
@@ -2,6 +2,7 @@ package com.soma.advice;
 
 import com.soma.exception.group.AlreadyJoinedGroupException;
 import com.soma.exception.group.GroupNotFoundException;
+import com.soma.exception.member.MemberNicknameAlreadyExistsException;
 import com.soma.exception.member.MemberNotFoundException;
 import com.soma.util.response.Response;
 import lombok.Getter;
@@ -39,5 +40,12 @@ public class ExceptionAdvice {
         return Response.failure(ALREADY_JOINED_GROUP_EXCEPTION);
     }
 
+    /* Auth */
+    @ExceptionHandler(MemberNicknameAlreadyExistsException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Response memberNicknameAlreadyExistsExceptionHandler(MemberNicknameAlreadyExistsException e){
+//        Sentry.captureException(e);
+        return Response.failure(MEMBER_ALREADY_EXIST);
+    }
 
 }

--- a/snackpot-api/src/test/java/com/soma/auth/service/AuthServiceTest.java
+++ b/snackpot-api/src/test/java/com/soma/auth/service/AuthServiceTest.java
@@ -1,0 +1,88 @@
+package com.soma.auth.service;
+
+import com.soma.auth.dto.request.SignUpRequest;
+import com.soma.domain.group.dto.request.GroupCreateRequest;
+import com.soma.domain.group.dto.response.GroupNameResponse;
+import com.soma.domain.group.factory.dto.GroupCreateFactory;
+import com.soma.domain.group.repository.GroupRepository;
+import com.soma.domain.group.service.GroupService;
+import com.soma.domain.joinlist.repository.JoinListRepository;
+import com.soma.domain.member.entity.Member;
+import com.soma.domain.member.factory.entity.MemberFactory;
+import com.soma.domain.member.factory.fixtures.MemberFixtures;
+import com.soma.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ActiveProfiles("test")
+@SpringBootTest
+//@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthService 비즈니스 로직 테스트")
+class AuthServiceTest {
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("같은 닉네임으로 동시에 회원가입을 시도할 때 Member 엔티티의 name 컬럼의 Unique 제약조건 덕분에 1명만 제대로 가입된다.")
+    @Test
+    void signupTest() throws Exception {
+        int threadCount = 32;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(32);//32개 스레드 생성
+        CountDownLatch latch = new CountDownLatch(threadCount); //스레드 완료 대기를 위해
+
+        for(int i=0; i<threadCount; i++){
+            executorService.submit(()->{
+                try{
+                    authService.signup(new SignUpRequest("테스트", 10, "fcmToken")); //문제의 메서드 호출
+                } finally {
+                    latch.countDown(); //완료되었음을 알림
+                }
+            });
+        }
+
+        latch.await(); // 모든 스레드가 완료될 때까지 기다렸다가, 모든 스레드가 완료되면 다음 코드로 진행
+        long count = memberRepository.count();
+
+        assertEquals(1L, count);
+    }
+
+
+    @Test
+    @DisplayName("Member 엔티티의 name 컬럼에 unique 제약조건 설정을 확인한다.")
+    void MemberNameUniqueConstraintTest() throws Exception {
+        //given
+
+        Member 김누구1 = MemberFactory.createUserRoleMemberWithNameAndEmail("김누구", "kim@gamilcom");
+        Member 김누구2 = MemberFactory.createUserRoleMemberWithNameAndEmail("김누구", "kim@gamilcom");
+
+        memberRepository.saveAndFlush(김누구1);
+
+
+        //when //then
+        Assertions.assertThrows(DataIntegrityViolationException.class, () -> memberRepository.save(김누구2));
+    }
+
+}

--- a/snackpot-domain/src/main/java/com/soma/domain/member/entity/Member.java
+++ b/snackpot-domain/src/main/java/com/soma/domain/member/entity/Member.java
@@ -13,6 +13,7 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true)
     private String name;
 
     private String email;


### PR DESCRIPTION
## 지라 이슈
- [SNK-98](https://soma-tall-i.atlassian.net/jira/software/projects/SNK/boards/2?selectedIssue=SNK-98)

## 작업사항
- 서비스 요구조건에 같은 이름의 회원이 존재할 수 없다는 요구사항이 있습니다. 그러나, 한 회원이 빠른 속도로 회원 가입 버튼을 누르는 경우, 같은 이름의 회원이 등록되는 문제를 발견하였습니다. 또한, 동시에 여러명의 회원이 같은 이름으로 회원가입을 시도하는 경우에도 같은 문제가 발생할 수 있습니다. MemberService에서 가입하려는 이름을 가진 회원이 있는지 select쿼리를 날려 확인하는 코드가 존재하지만, 스프링이 멀티스레드를 지원해, 두개 이상의 스레드가 동시에 DB에서 회원가입할 이름으로 select하는 경우, 두 스레드 모두 해당 이름을 가진 회원이 없다고 판단해, insert쿼리를 날려, 같은 이름을 가진 두명의 사용자가 DB에 저장되게 됩니다.
- 해당 문제를 Member 엔티티의 name 컬럼에 unique 제약조건을 걸어 해결하였습니다.


[SNK-98]: https://soma-tall-i.atlassian.net/browse/SNK-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ