### PR TITLE
fix : 로그인, 회원가입 시 fcm 토큰 전달하지 않고, 알림이 필요한 콕 찌르기를 할 때 fcm 토큰 전달하도록 수정

### DIFF
--- a/snackpot-api/src/main/java/com/soma/advice/ErrorCode.java
+++ b/snackpot-api/src/main/java/com/soma/advice/ErrorCode.java
@@ -16,8 +16,11 @@ public enum ErrorCode {
     GROUP_NOT_FOUND_EXCEPTION(-1201, "그룹이 존재하지 않습니다."),
 
     /* Exercise */
-    EXERCISE_NOT_FOUND_EXCEPTION(-1300, "운동이 존재하지 않습니다.");
+    EXERCISE_NOT_FOUND_EXCEPTION(-1300, "운동이 존재하지 않습니다."),
 
+
+    /* Notification */
+    FCM_TOKEN_NOT_FOUND_EXCEPTION(-1400, "FCM 토큰을 찾을 수 없습니다.");
     private final int code;
     private final String message;
 }

--- a/snackpot-api/src/main/java/com/soma/advice/ExceptionAdvice.java
+++ b/snackpot-api/src/main/java/com/soma/advice/ExceptionAdvice.java
@@ -3,6 +3,7 @@ package com.soma.advice;
 import com.soma.exception.exercise.ExerciseNotFoundException;
 import com.soma.exception.group.AlreadyJoinedGroupException;
 import com.soma.exception.group.GroupNotFoundException;
+import com.soma.exception.member.FCMTokenNotFoundException;
 import com.soma.exception.member.MemberNicknameAlreadyExistsException;
 import com.soma.exception.member.MemberNotFoundException;
 import com.soma.util.response.Response;
@@ -55,4 +56,11 @@ public class ExceptionAdvice {
         return Response.failure(EXERCISE_NOT_FOUND_EXCEPTION);
     }
 
+    /* Notification */
+    @ExceptionHandler(FCMTokenNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Response fcmTokenNotFoundExceptionHandler(FCMTokenNotFoundException e){
+        log.error(FCM_TOKEN_NOT_FOUND_EXCEPTION.getMessage());
+        return Response.failure(FCM_TOKEN_NOT_FOUND_EXCEPTION);
+    }
 }

--- a/snackpot-api/src/main/java/com/soma/auth/dto/request/SignInRequest.java
+++ b/snackpot-api/src/main/java/com/soma/auth/dto/request/SignInRequest.java
@@ -13,7 +13,4 @@ public class SignInRequest {
     @NotBlank(message = "이름은 필수입니다.")
     @Size(min = 1, max = 6, message = "이름은 1자 이상 6자 이하로 입력해주세요.")
     private String name;
-
-    @NotBlank(message = "fcm 토큰은 필수 값입니다.")
-    private String fcmToken;
 }

--- a/snackpot-api/src/main/java/com/soma/auth/dto/request/SignUpRequest.java
+++ b/snackpot-api/src/main/java/com/soma/auth/dto/request/SignUpRequest.java
@@ -19,7 +19,4 @@ public class SignUpRequest {
     @NotNull(message = "일일 목표 시간은 필수입니다.")
     @Min(value = 0, message = "일일 목표 시간은 0초 이상이어야 합니다.")
     private Integer dailyGoalTime;
-
-    @NotBlank(message = "fcm 토큰은 필수 값입니다.")
-    private String fcmToken;
 }

--- a/snackpot-api/src/main/java/com/soma/auth/service/AuthService.java
+++ b/snackpot-api/src/main/java/com/soma/auth/service/AuthService.java
@@ -38,8 +38,6 @@ public class AuthService {
                 .dailyGoalTime(request.getDailyGoalTime())
                 .roleType(RoleType.USER)
                 .build();
-        // fcm 토큰 저장
-        member.updateFcmToken(request.getFcmToken());
 
         memberRepository.save(member);
 
@@ -53,9 +51,6 @@ public class AuthService {
         Member member = memberRepository.findByNameAndStatus(request.getName(), Status.ACTIVE).orElseThrow(MemberNotFoundException::new);
 
         String accessToken = jwtService.createAccessToken(member.getEmail());
-
-        // fcm 토큰 저장
-        member.updateFcmToken(request.getFcmToken());
 
         return new SignInResponse("Bearer " + accessToken, member.getId());
     }

--- a/snackpot-api/src/main/java/com/soma/domain/notification/dto/request/NotificationCreateRequest.java
+++ b/snackpot-api/src/main/java/com/soma/domain/notification/dto/request/NotificationCreateRequest.java
@@ -1,5 +1,6 @@
 package com.soma.domain.notification.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,4 +9,7 @@ import lombok.NoArgsConstructor;
 public class NotificationCreateRequest {
     private Long groupId;
     private Long toUserId;
+
+    @NotBlank(message = "fcm 토큰은 필수 값입니다.")
+    private String fcmToken;
 }

--- a/snackpot-api/src/main/java/com/soma/domain/notification/service/NotificationService.java
+++ b/snackpot-api/src/main/java/com/soma/domain/notification/service/NotificationService.java
@@ -5,6 +5,7 @@ import com.soma.domain.group.entity.Group;
 import com.soma.domain.notification.NotificationMessage;
 import com.soma.domain.notification.dto.request.NotificationCreateRequest;
 import com.soma.exception.group.GroupNotFoundException;
+import com.soma.exception.member.FCMTokenNotFoundException;
 import com.soma.exception.member.MemberNotFoundException;
 import com.soma.domain.group.repository.GroupRepository;
 import com.soma.domain.member.entity.Member;
@@ -40,11 +41,15 @@ public class NotificationService {
     }
 
 
+    @Transactional(noRollbackFor = FCMTokenNotFoundException.class)
     public void create(NotificationCreateRequest request, String email) {
         Group group = groupRepository.findById(request.getGroupId()).orElseThrow(GroupNotFoundException::new);
         Member fromMember = memberRepository.findByEmailAndStatus(email, ACTIVE).orElseThrow(MemberNotFoundException::new);
+        fromMember.updateFcmToken(request.getFcmToken());
         Member toMember = memberRepository.findByIdAndStatus(request.getToUserId(), ACTIVE).orElseThrow(MemberNotFoundException::new);
-
+        if(toMember.getFcmToken() == null){
+            throw new FCMTokenNotFoundException();
+        }
         int idx = random.nextInt(notificationMessages.size());
 
         firebaseCloudMessageService.sendByToken(toMember.getFcmToken(), notificationMessages.get(idx).getTitleWithNicknameAndGroupName(group.getName(), fromMember.getName()), notificationMessages.get(idx).getBody());

--- a/snackpot-api/src/main/java/com/soma/exception/member/FCMTokenNotFoundException.java
+++ b/snackpot-api/src/main/java/com/soma/exception/member/FCMTokenNotFoundException.java
@@ -1,0 +1,4 @@
+package com.soma.exception.member;
+
+public class FCMTokenNotFoundException extends RuntimeException{
+}

--- a/snackpot-api/src/test/java/com/soma/auth/service/AuthServiceTest.java
+++ b/snackpot-api/src/test/java/com/soma/auth/service/AuthServiceTest.java
@@ -56,7 +56,7 @@ class AuthServiceTest {
         for(int i=0; i<threadCount; i++){
             executorService.submit(()->{
                 try{
-                    authService.signup(new SignUpRequest("테스트", 10, "fcmToken")); //문제의 메서드 호출
+                    authService.signup(new SignUpRequest("테스트", 10)); //문제의 메서드 호출
                 } finally {
                     latch.countDown(); //완료되었음을 알림
                 }


### PR DESCRIPTION
## 연관 이슈
- closed #61 

## 작업사항
1. 로그인/회원가입 API 
- request에서 fcmToken 제거 
- service에서 fcm토큰 저장 로직 제거

2. 콕 찌르기 API
- 콕 찌르기 누른 사용자의 fcm Token 저장
    - 상대방의 fcmToken이 null이라서 FCMTokenNotFoundException이 발생하더라도 나의 fcm Token은 저장되도록 noRollbackFor 옵션 사용
- FCMTokenNotFoundException 에러코드, 에러핸들러 추가
