### PR TITLE
fix : 운동 수행 결과표 로직 수정에 따라 통합테스트 수정

### DIFF
--- a/snackpot-api/src/test/java/com/soma/domain/group/controller/GroupControllerIntegrationTest.java
+++ b/snackpot-api/src/test/java/com/soma/domain/group/controller/GroupControllerIntegrationTest.java
@@ -339,7 +339,7 @@ public class GroupControllerIntegrationTest {
         Group 그룹 = GroupFactory.createGroup();
         groupRepository.save(그룹);
 
-        Member 회원A = MemberFactory.createUserRoleMemberWithNameAndEmailAndDailyGoalTime("회원A", "A@gmail.com", 10);
+        Member 회원A = MemberFactory.createUserRoleMemberWithNameAndEmailAndDailyGoalTime("회원A", "A@gmail.com", 10); // 분 단위
         Member 회원B = MemberFactory.createUserRoleMemberWithNameAndEmailAndDailyGoalTime("회원B", "B@gmail.com", 20);
         memberRepository.saveAll(List.of(회원A, 회원B));
 
@@ -356,11 +356,11 @@ public class GroupControllerIntegrationTest {
         LocalDateTime 수 = localDateTimeOfThisWeek(3);
         LocalDateTime 일 = localDateTimeOfThisWeek(7);
 
-        ExerciseRecord 기록A = ExerciseRecordFactory.createExerciseRecordWithExerciseAndMemberAndTime(운동, 회원A, 9);
-        ExerciseRecord 기록B = ExerciseRecordFactory.createExerciseRecordWithExerciseAndMemberAndTime(운동, 회원A, 11);
-        ExerciseRecord 기록C = ExerciseRecordFactory.createExerciseRecordWithExerciseAndMemberAndTime(운동, 회원B, 19);
-        ExerciseRecord 기록D = ExerciseRecordFactory.createExerciseRecordWithExerciseAndMemberAndTime(운동, 회원B, 21);
-        ExerciseRecord 기록E = ExerciseRecordFactory.createExerciseRecordWithExerciseAndMemberAndTime(운동, 회원B, 25);
+        ExerciseRecord 기록A = ExerciseRecordFactory.createExerciseRecordWithExerciseAndMemberAndTime(운동, 회원A, 10*60-1);// 초 단위
+        ExerciseRecord 기록B = ExerciseRecordFactory.createExerciseRecordWithExerciseAndMemberAndTime(운동, 회원A, 10*60);
+        ExerciseRecord 기록C = ExerciseRecordFactory.createExerciseRecordWithExerciseAndMemberAndTime(운동, 회원B, 20*60-1);
+        ExerciseRecord 기록D = ExerciseRecordFactory.createExerciseRecordWithExerciseAndMemberAndTime(운동, 회원B, 20*60);
+        ExerciseRecord 기록E = ExerciseRecordFactory.createExerciseRecordWithExerciseAndMemberAndTime(운동, 회원B, 20*60+1);
         exerciseRecordRepository.saveAll(List.of(기록A, 기록B, 기록C, 기록D, 기록E));
         기록A.updateCreatedAt(월);
         기록B.updateCreatedAt(수);


### PR DESCRIPTION
### 작업사항
- 운동 수행 시간은 초단위, 개인 하루 운동 목표시간은 분단위로 시간 단위 차이에 따라 테스트의 given 데이터가 잘못 작성되어있었습니다. 운동 기록시 분 단위가 아닌 초단위로 기록되기에, 기존에 분 단위로 작성되어있던 운동 기록 시간을 초 단위로 수정하였습니다.